### PR TITLE
Enable sign editing if user has `nabsuite.editsigns` permission

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/mechs/signedit/SignEditDisabler.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/mechs/signedit/SignEditDisabler.java
@@ -16,6 +16,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import java.time.Duration;
 
 public class SignEditDisabler implements Listener {
+    private final String editSignPerm = "nabsuite.editsigns";
     private final Cache<Location, Location> locationCache = CacheBuilder.newBuilder().expireAfterAccess(Duration.ofMinutes(5)).build();
 
     public SignEditDisabler(MechsModule mechsModule) {
@@ -26,8 +27,10 @@ public class SignEditDisabler implements Listener {
     private void onSignOpen(PlayerOpenSignEvent event) {
         if (event.getCause() == PlayerOpenSignEvent.Cause.INTERACT) {
             if (locationCache.getIfPresent(event.getSign().getLocation()) == null) {
-                event.setCancelled(true);
-                event.getPlayer().sendMessage(Component.text("Sign editing is temporarily disabled.", NamedTextColor.RED));
+                if (!event.getPlayer().hasPermission(editSignPerm)) {
+                    event.setCancelled(true);
+                    event.getPlayer().sendMessage(Component.text("You do not have permission to edit signs.", NamedTextColor.RED));
+                }
             }
         }
     }

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/area/flag/enforcers/NoBuildFlagEnforcer.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/area/flag/enforcers/NoBuildFlagEnforcer.java
@@ -4,6 +4,7 @@ import com.froobworld.nabsuite.modules.protect.area.AreaLike;
 import com.froobworld.nabsuite.modules.protect.area.AreaManager;
 import com.froobworld.nabsuite.modules.protect.area.flag.Flags;
 import com.froobworld.nabsuite.modules.protect.util.PlayerCauser;
+import io.papermc.paper.event.player.PlayerOpenSignEvent;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.ArmorStand;
@@ -80,6 +81,16 @@ public class NoBuildFlagEnforcer implements Listener {
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
     public void onSignChange(SignChangeEvent event) {
         if (!canBuild(event.getBlock().getLocation(), event.getPlayer(), true)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    private void onSignOpen(PlayerOpenSignEvent event) {
+        if (event.getCause() != PlayerOpenSignEvent.Cause.INTERACT) {
+            return;
+        }
+        if (!canBuild(event.getSign().getLocation(), event.getPlayer(), true)) {
             event.setCancelled(true);
         }
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -291,6 +291,8 @@ permissions:
   # Mechs module other permissions
   nabsuite.nabmode:
     description: "Allows player access to nab mode."
+  nabsuite.editsigns:
+    description: "Allows player to edit signs"
 
   # Protect module commands
   nabsuite.command.area:


### PR DESCRIPTION
* Added new permission `nabsuite.editsigns`
* Allow players with permission to edit signs
* Don't allow the sign editor to open if the player lacks build permission in area