### PR TITLE
Prevent RandomTeleporter from picking a location inside powdered snow

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/basics/teleport/random/RandomTeleporter.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/teleport/random/RandomTeleporter.java
@@ -7,6 +7,7 @@ import com.froobworld.nabsuite.modules.basics.teleport.home.Homes;
 import com.froobworld.nabsuite.modules.protect.ProtectModule;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 
@@ -64,6 +65,12 @@ public class RandomTeleporter {
                         if (block.isSolid()) {
                             Location newLocation = location.clone();
                             newLocation.setY(block.getY() + 1);
+                            for (int i = 0; i < 5; i++) {
+                                Block checkBlock = location.getWorld().getBlockAt(newLocation.getBlockX(), newLocation.getBlockY() + i, newLocation.getBlockZ());
+                                if (checkBlock.getType() == Material.POWDER_SNOW) {
+                                    return CompletableFuture.completedFuture(null);
+                                }
+                            }
                             return CompletableFuture.completedFuture(newLocation);
                         }
                     }


### PR DESCRIPTION
I noticed the other day a player doing `/rtp` and ending up inside powdered snow.

After a bit of testing, it turns out that `getHighestBlockAt()` does not take powdered snow into account (description: "Gets the highest non-empty (impassable) block at the given coordinates.")

This change prevents that by checking if the selected block or any of the 4 blocks above is powdered snow