### PR TITLE
Add `/area near` command

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/protect/area/Area.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/area/Area.java
@@ -317,6 +317,47 @@ public class Area implements AreaLike {
         return subAreas.isEmpty() ? Collections.singleton(this) : subAreas;
     }
 
+    public Location closestLocation(Location location) {
+        if (!location.getWorld().equals(this.world)) {
+            return null;
+        }
+        int minX = Math.min(corner1.getBlockX(), corner2.getBlockX());
+        int maxX = Math.max(corner1.getBlockX(), corner2.getBlockX());
+        int minY = Math.min(corner1.getBlockY(), corner2.getBlockY());
+        int maxY = Math.max(corner1.getBlockY(), corner2.getBlockY());
+        int minZ = Math.min(corner1.getBlockZ(), corner2.getBlockZ());
+        int maxZ = Math.max(corner1.getBlockZ(), corner2.getBlockZ());
+        double x = location.getBlockX() >= minX && location.getBlockX() <= maxX ? location.getX() : (
+                location.getBlockX() < minX ? minX : maxX
+        );
+        double y = location.getBlockY() >= minY && location.getBlockY() <= maxY ? location.getY() : (
+                location.getBlockY() < minY ? minY : maxY
+        );
+        double z = location.getBlockZ() >= minZ && location.getBlockZ() <= maxZ ? location.getZ() : (
+                location.getBlockZ() < minZ ? minZ : maxZ
+        );
+        return new Location(location.getWorld(), x, y, z);
+    }
+
+    public Set<Area> getAreasNear(Location location, int radius) {
+        if (!this.isApproved() || !location.getWorld().equals(this.world)) {
+            return Collections.emptySet();
+        }
+        if (this.containsLocation(location)) {
+            // If player is inside an area that has subareas within the radius, only show those
+            Set<Area> subAreas = new HashSet<>();
+            for (Area area : children) {
+                subAreas.addAll(area.getAreasNear(location, radius));
+            }
+            return subAreas.isEmpty() ? Collections.singleton(this) : subAreas;
+        }
+        Location areaEdge = closestLocation(location);
+        if (areaEdge == null || areaEdge.distanceSquared(location) > radius*radius) {
+            return Collections.emptySet();
+        }
+        return Collections.singleton(this);
+    }
+
     private void scheduleSave() {
         if (parent != null) {
             parent.scheduleSave();

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/area/AreaManager.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/area/AreaManager.java
@@ -162,6 +162,16 @@ public class AreaManager {
         return false;
     }
 
+    public Set<Area> getAreasNear(Location location, int radius) {
+        Set<Area> areaSet = new HashSet<>();
+        for (Area area: areaMap.values()) {
+            if (area.isApproved()) {
+                areaSet.addAll(area.getAreasNear(location, radius));
+            }
+        }
+        return areaSet;
+    }
+
     public GlobalAreaManager getGlobalAreaManager() {
         return globalAreaManager;
     }

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/command/AreaCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/command/AreaCommand.java
@@ -17,6 +17,7 @@ public class AreaCommand extends NabParentCommand {
         );
         childCommands.addAll(List.of(
                 new AreaHereCommand(protectModule),
+                new AreaNearCommand(protectModule),
                 new AreaInfoCommand(protectModule),
                 new AreaAddUserCommand(protectModule),
                 new AreaAddManagerCommand(protectModule),

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/command/AreaNearCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/command/AreaNearCommand.java
@@ -1,0 +1,108 @@
+package com.froobworld.nabsuite.modules.protect.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.context.CommandContext;
+import com.froobworld.nabsuite.command.NabCommand;
+import com.froobworld.nabsuite.command.argument.arguments.NumberArgument;
+import com.froobworld.nabsuite.modules.protect.ProtectModule;
+import com.froobworld.nabsuite.modules.protect.area.Area;
+import com.froobworld.nabsuite.util.NumberDisplayer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class AreaNearCommand extends NabCommand {
+    private final ProtectModule protectModule;
+
+    public AreaNearCommand(ProtectModule protectModule) {
+        super(
+                "near",
+                "Get a list of areas near your location.",
+                "nabsuite.command.area.near",
+                Player.class
+        );
+        this.protectModule = protectModule;
+    }
+
+    @Override
+    public void execute(CommandContext<CommandSender> context) {
+
+        Optional<Integer> radiusArg = context.getOptional("radius");
+        Integer radius = radiusArg.orElse(protectModule.getConfig().areaNearSettings.radius.get());
+        Integer limit = protectModule.getConfig().areaNearSettings.limit.get();
+
+        Player sender = (Player) context.getSender();
+        Location loc = sender.getLocation();
+        List<AreaDistance> areas = protectModule.getAreaManager().getAreasNear(loc, radius).stream()
+                .map(area -> new AreaDistance(area, area.closestLocation(loc).distance(loc)))
+                .sorted(Comparator.comparingDouble(a -> a.distance))
+                .limit(limit)
+                .toList();
+
+        String radiusStr = NumberDisplayer.toStringWithModifier(radius, " block", " blocks", false);
+
+        if (areas.isEmpty()) {
+            sender.sendMessage(
+                    Component.text("There are no areas within "+radiusStr+" of your location.").color(NamedTextColor.YELLOW)
+            );
+        } else {
+            List<Component> list = areas.stream()
+                    .map(a -> Component.empty()
+                            .append(
+                                Component.text(a.area.getLongFormName())
+                                        .clickEvent(ClickEvent.runCommand("/area info "+a.area.getLongFormName()))
+                                        .color(NamedTextColor.RED)
+                            )
+                            .append(Component.text(" "))
+                            .append(
+                                Component.text("(" + (a.distance == 0 ? "here" : (int)Math.ceil(a.distance)) + ")")
+                                        .clickEvent(ClickEvent.runCommand("/area visualise "+a.area.getLongFormName()))
+                            )
+                    )
+                    .collect(Collectors.toList());
+            sender.sendMessage(
+                    Component.text("There " + NumberDisplayer.toStringWithModifierAndPrefix(areas.size(), " area", " areas", "is "+(areas.size()==limit?"at least ":""), "are "+(areas.size()==limit?"at least ":"")))
+                            .append(Component.text(" within "+radiusStr+" of your location.")).color(NamedTextColor.YELLOW)
+            );
+            sender.sendMessage(Component.join(JoinConfiguration.separator(Component.text(", ")), list));
+        }
+    }
+
+    @Override
+    public Command.Builder<CommandSender> populateBuilder(Command.Builder<CommandSender> builder) {
+        return builder
+                .argument(
+                        new NumberArgument<>(
+                                false,
+                                "radius",
+                                context -> 1,
+                                context -> protectModule.getConfig().areaNearSettings.maxRadius.get()
+                        )
+                );
+    }
+
+    @Override
+    public String getUsage() {
+        return "/area near [radius]";
+    }
+
+    private static class AreaDistance {
+        private final Area area;
+        private final double distance;
+
+        public AreaDistance(Area area, double distance) {
+            this.area = area;
+            this.distance = distance;
+        }
+    }
+
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/config/ProtectConfig.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/config/ProtectConfig.java
@@ -1,14 +1,16 @@
 package com.froobworld.nabsuite.modules.protect.config;
 
 import com.froobworld.nabconfiguration.ConfigEntry;
+import com.froobworld.nabconfiguration.ConfigSection;
 import com.froobworld.nabconfiguration.NabConfiguration;
 import com.froobworld.nabconfiguration.annotations.Entry;
+import com.froobworld.nabconfiguration.annotations.Section;
 import com.froobworld.nabsuite.modules.protect.ProtectModule;
 
 import java.io.File;
 
 public class ProtectConfig extends NabConfiguration {
-    private static final int CONFIG_VERSION = 1;
+    private static final int CONFIG_VERSION = 2;
 
     public ProtectConfig(ProtectModule protectModule) {
         super(
@@ -22,5 +24,18 @@ public class ProtectConfig extends NabConfiguration {
     @Entry(key = "map-url")
     public ConfigEntry<String> mapReviewUrl = new ConfigEntry<>();
 
+    @Section(key = "area-near")
+    public final AreaNearSettings areaNearSettings = new AreaNearSettings();
 
+    public static class AreaNearSettings extends ConfigSection {
+
+        @Entry(key = "radius")
+        public ConfigEntry<Integer> radius = new ConfigEntry<>();
+
+        @Entry(key = "max-radius")
+        public ConfigEntry<Integer> maxRadius = new ConfigEntry<>();
+
+        @Entry(key = "limit")
+        public ConfigEntry<Integer> limit = new ConfigEntry<>();
+    }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -361,6 +361,10 @@ permissions:
     description: "Access to the /area visualise command."
     children:
       - nabsuite.command.area
+  nabsuite.command.area.near:
+    description: "Access to the /area near command."
+    children:
+      - nabsuite.command.area
   nabsuite.command.redefinearea:
     description: "Access to the /redefinearea command."
   nabsuite.command.areas:

--- a/src/main/resources/resources/protect/config-patches/1.patch
+++ b/src/main/resources/resources/protect/config-patches/1.patch
@@ -1,0 +1,18 @@
+[add-section]
+key=area-near
+comment=# Settings related to /area near command
+
+[add-field]
+key=area-near.radius
+value=100
+comment=# Default radius
+
+[add-field]
+key=area-near.max-radius
+value=250
+comment=# Maximum allowed radius
+
+[add-field]
+key=area-near.limit
+value=20
+comment=# Max number of results to display.

--- a/src/main/resources/resources/protect/config.yml
+++ b/src/main/resources/resources/protect/config.yml
@@ -1,5 +1,16 @@
 # Don't edit this.
-version: 1
+version: 2
 
 # What is the URL of the Dynmap instance?
 map-url: "http://s.froobworld.com:8124/"
+
+# Settings related to /area near command
+area-near:
+  # Default radius
+  radius: 100
+
+  # Maximum allowed radius
+  max-radius: 250
+
+  # Max number of results to display.
+  limit: 20


### PR DESCRIPTION
Adds the subcommand `/area near` for players with permission `nabsuite.command.area.near`.

If the player is inside an area that has subareas within the radius - those subareas will be shown instead of the parent area.

Default radius, max radius and max areas to display can be configured in `protect/config.yml`

