### PR TITLE
RTP Improvements

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/basics/command/RandomTeleportCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/command/RandomTeleportCommand.java
@@ -24,6 +24,7 @@ public class RandomTeleportCommand extends NabCommand {
                 "randomteleport", "randomtp", "wild"
         );
         this.basicsModule = basicsModule;
+        childCommands.add(new RandomTeleportStatusCommand(basicsModule));
     }
 
     @Override

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/command/RandomTeleportStatusCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/command/RandomTeleportStatusCommand.java
@@ -41,7 +41,7 @@ public class RandomTeleportStatusCommand extends NabCommand {
                         .color(NamedTextColor.WHITE)
         ).toList();
         context.getSender().sendMessage(
-                Component.text("RTP Pre-generation status: ", NamedTextColor.YELLOW)
+                Component.text("RTP pre-generation status: ", NamedTextColor.YELLOW)
                     .append(
                             status.isEmpty() ?
                                     Component.text("No active worlds").color(NamedTextColor.GRAY) :

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/command/RandomTeleportStatusCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/command/RandomTeleportStatusCommand.java
@@ -1,0 +1,61 @@
+package com.froobworld.nabsuite.modules.basics.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.context.CommandContext;
+import com.froobworld.nabsuite.command.NabCommand;
+import com.froobworld.nabsuite.modules.basics.BasicsModule;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+
+import java.util.List;
+
+public class RandomTeleportStatusCommand extends NabCommand {
+    private final BasicsModule basicsModule;
+
+    public RandomTeleportStatusCommand(BasicsModule basicsModule) {
+        super(
+                "status",
+                "Show random teleport status.",
+                "nabsuite.command.rtp.status",
+                CommandSender.class
+        );
+        this.basicsModule = basicsModule;
+    }
+
+    @Override
+    public void execute(CommandContext<CommandSender> context) {
+        List<TextComponent> status = basicsModule.getRandomTeleportManager().getRandomTeleportStatus().stream().map(
+                s -> Component.text(s.getWorld().getName())
+                        .append(Component.text(" ("))
+                        .append(s.getPregenerateMax() == 0 ?
+                                Component.text("disabled").color(NamedTextColor.GRAY) :
+                                Component.text(s.getPregenerated() + "/" + s.getPregenerateMax())
+                                        .color(
+                                                s.getPregenerated() >= s.getPregenerateMax() ? NamedTextColor.GREEN :
+                                                s.getPregenerated() == 0 ? NamedTextColor.RED : NamedTextColor.YELLOW)
+                        )
+                        .append(Component.text(")"))
+                        .color(NamedTextColor.WHITE)
+        ).toList();
+        context.getSender().sendMessage(
+                Component.text("RTP Pre-generation status: ", NamedTextColor.YELLOW)
+                    .append(
+                            status.isEmpty() ?
+                                    Component.text("No active worlds").color(NamedTextColor.GRAY) :
+                                    Component.join(JoinConfiguration.separator(Component.text(", ")), status)
+                    )
+        );
+    }
+    @Override
+    public Command.Builder<CommandSender> populateBuilder(Command.Builder<CommandSender> builder) {
+        return builder;
+    }
+
+    @Override
+    public String getUsage() {
+        return "/rtp status";
+    }
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/config/BasicsConfig.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/config/BasicsConfig.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.function.Function;
 
 public class BasicsConfig extends NabConfiguration {
-    private static final int CONFIG_VERSION = 4;
+    private static final int CONFIG_VERSION = 5;
 
     public BasicsConfig(BasicsModule basicsModule) {
         super(
@@ -131,6 +131,15 @@ public class BasicsConfig extends NabConfiguration {
 
             @Entry(key = "exclusion-radius-z")
             public final ConfigEntry<Integer> exclusionRadiusZ = ConfigEntries.integerEntry();
+
+            @Entry(key = "exclude-biomes")
+            public final ConfigEntry<List<String>> excludeBiomes = ConfigEntries.stringListEntry();
+
+            @Entry(key = "pregenerate-max")
+            public final ConfigEntry<Integer> pregenerateMax = ConfigEntries.integerEntry();
+
+            @Entry(key = "pregenerate-interval")
+            public final ConfigEntry<Integer> pregenerateInterval = ConfigEntries.integerEntry();
 
         }
 

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/teleport/random/RandomTeleportManager.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/teleport/random/RandomTeleportManager.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.persistence.PersistentDataType;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -42,6 +43,10 @@ public class RandomTeleportManager {
     public long getTimeUntilNextRandomTeleport(Player player) {
         updateAllowance(player);
         return getRegenerationTimestamp(player) + regenerationFrequency - System.currentTimeMillis();
+    }
+
+    public List<RandomTeleporter.WorldStatus> getRandomTeleportStatus() {
+        return randomTeleporter.getStatus();
     }
 
     public CompletableFuture<Location> randomTeleport(Player player) {

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/teleport/random/RandomTeleporter.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/teleport/random/RandomTeleporter.java
@@ -9,19 +9,75 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class RandomTeleporter {
     private final Random random = new Random();
     private static final int MAX_ATTEMPTS = 50;
     private static final double MIN_DISTANCE_FROM_HOME = 300;
     private final BasicsModule basicsModule;
+    private final Map<World, Queue<Location>> pregenerated = new HashMap<>();
+    private final Map<World, Set<Biome>> excludeBiomes = new HashMap<>();
 
     public RandomTeleporter(BasicsModule basicsModule) {
         this.basicsModule = basicsModule;
+
+        int offset = 0;
+        for (String worldName: basicsModule.getConfig().randomTeleport.enabledWorlds.get()) {
+            final World world = Bukkit.getWorld(worldName);
+            if (world == null) {
+                continue;
+            }
+            final BasicsConfig.RandomTeleportSettings.WorldSettings worldSettings = basicsModule.getConfig().randomTeleport.worldSettings.of(world);
+            if (worldSettings == null) {
+                continue;
+            }
+
+            excludeBiomes.put(world, new HashSet<>(
+                    worldSettings.excludeBiomes.get()
+                            .stream()
+                            .map(name -> {
+                                for (Biome biome: Biome.values()) {
+                                    if (biome.name().equalsIgnoreCase(name.trim())) {
+                                        return biome;
+                                    }
+                                }
+                                basicsModule.getPlugin().getSLF4JLogger().warn("RandomTeleporter unknown biome in exclude-biomes: " + name);
+                                return null;
+                            })
+                            .filter(Objects::nonNull)
+                            .toList())
+            );
+
+            final Integer pregenerateMax = worldSettings.pregenerateMax.get();
+            final Integer pregenerateInterval = worldSettings.pregenerateInterval.get();
+            if (pregenerateMax != null && pregenerateInterval != null && pregenerateMax > 0 && pregenerateInterval > 0) {
+                final Queue<Location> pregeneratedLocations = new ConcurrentLinkedQueue<>();
+                pregenerated.put(world, pregeneratedLocations);
+                Bukkit.getScheduler().runTaskTimerAsynchronously(
+                        basicsModule.getPlugin(),
+                        () -> this.pregenerateTeleports(world, pregeneratedLocations, pregenerateMax),
+                        pregenerateInterval + offset,
+                        pregenerateInterval
+                );
+                // Stagger initial delay between worlds
+                offset += 20;
+            }
+
+        }
     }
 
     public CompletableFuture<Location> attemptFindLocation(World world) {
@@ -32,7 +88,11 @@ public class RandomTeleporter {
         if (attemptNumber >= MAX_ATTEMPTS) {
             return CompletableFuture.completedFuture(null);
         }
-        return testLocation(generateRandomLocation(world))
+        Location randomLocation = pregenerated.containsKey(world) ? pregenerated.get(world).poll() : null;
+        if (randomLocation == null) {
+            randomLocation = generateRandomLocation(world);
+        }
+        return testLocation(randomLocation)
                 .thenComposeAsync(location -> {
                     if (location != null) {
                         return CompletableFuture.completedFuture(location);
@@ -65,6 +125,9 @@ public class RandomTeleporter {
                 .thenCompose(chunk -> {
                     if (chunk != null) {
                         Block block = location.getWorld().getHighestBlockAt(location);
+                        if (excludeBiomes.containsKey(location.getWorld()) && excludeBiomes.get(location.getWorld()).contains(block.getBiome())) {
+                            return CompletableFuture.completedFuture(null);
+                        }
                         if (block.isSolid()) {
                             Location newLocation = location.clone();
                             newLocation.setY(block.getY() + 1);
@@ -99,4 +162,60 @@ public class RandomTeleporter {
         return location;
     }
 
+    private void pregenerateTeleports(World world, Queue<Location> queue, Integer maxLocations) {
+        if (queue.size() >= maxLocations) {
+            return;
+        }
+        testLocation(generateRandomLocation(world))
+                .thenComposeAsync(location -> {
+                    if (location != null) {
+                        queue.add(location);
+                    }
+                    return CompletableFuture.completedFuture(location);
+                }, Bukkit.getScheduler().getMainThreadExecutor(basicsModule.getPlugin()));
+    }
+
+    public List<WorldStatus> getStatus() {
+        List<WorldStatus> status = new LinkedList<>();
+        for (String worldName: basicsModule.getConfig().randomTeleport.enabledWorlds.get()) {
+            final World world = Bukkit.getWorld(worldName);
+            if (world == null) {
+                continue;
+            }
+            final BasicsConfig.RandomTeleportSettings.WorldSettings worldSettings = basicsModule.getConfig().randomTeleport.worldSettings.of(world);
+            if (worldSettings == null) {
+                continue;
+            }
+            status.add(new WorldStatus(
+                    world,
+                    pregenerated.containsKey(world) ? pregenerated.get(world).size() : 0,
+                    worldSettings.pregenerateMax.get()
+            ));
+        }
+        return status;
+    }
+
+    public static class WorldStatus {
+        private final World world;
+        private final Integer pregenerated;
+        private final Integer pregenerateMax;
+
+        public WorldStatus(World world, Integer pregenerated, Integer pregenerateMax) {
+            this.world = world;
+            this.pregenerated = pregenerated;
+            this.pregenerateMax = pregenerateMax;
+        }
+
+        public World getWorld() {
+            return world;
+        }
+
+        public Integer getPregenerated() {
+            return pregenerated;
+        }
+
+        public Integer getPregenerateMax() {
+            return pregenerateMax;
+        }
+    }
 }

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/teleport/random/RandomTeleporter.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/teleport/random/RandomTeleporter.java
@@ -62,12 +62,12 @@ public class RandomTeleporter {
                             .toList())
             );
 
-            final Integer pregenerateMax = worldSettings.pregenerateMax.get();
-            final Integer pregenerateInterval = worldSettings.pregenerateInterval.get();
-            if (pregenerateMax != null && pregenerateInterval != null && pregenerateMax > 0 && pregenerateInterval > 0) {
+            final int pregenerateMax = worldSettings.pregenerateMax.get();
+            final int pregenerateInterval = worldSettings.pregenerateInterval.get();
+            if (pregenerateMax > 0 && pregenerateInterval > 0) {
                 final Queue<Location> pregeneratedLocations = new ConcurrentLinkedQueue<>();
                 pregenerated.put(world, pregeneratedLocations);
-                Bukkit.getScheduler().runTaskTimerAsynchronously(
+                Bukkit.getScheduler().runTaskTimer(
                         basicsModule.getPlugin(),
                         () -> this.pregenerateTeleports(world, pregeneratedLocations, pregenerateMax),
                         pregenerateInterval + offset,
@@ -162,7 +162,7 @@ public class RandomTeleporter {
         return location;
     }
 
-    private void pregenerateTeleports(World world, Queue<Location> queue, Integer maxLocations) {
+    private void pregenerateTeleports(World world, Queue<Location> queue, int maxLocations) {
         if (queue.size() >= maxLocations) {
             return;
         }
@@ -197,10 +197,10 @@ public class RandomTeleporter {
 
     public static class WorldStatus {
         private final World world;
-        private final Integer pregenerated;
-        private final Integer pregenerateMax;
+        private final int pregenerated;
+        private final int pregenerateMax;
 
-        public WorldStatus(World world, Integer pregenerated, Integer pregenerateMax) {
+        public WorldStatus(World world, int pregenerated, int pregenerateMax) {
             this.world = world;
             this.pregenerated = pregenerated;
             this.pregenerateMax = pregenerateMax;
@@ -210,11 +210,11 @@ public class RandomTeleporter {
             return world;
         }
 
-        public Integer getPregenerated() {
+        public int getPregenerated() {
             return pregenerated;
         }
 
-        public Integer getPregenerateMax() {
+        public int getPregenerateMax() {
             return pregenerateMax;
         }
     }

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/teleport/random/RandomTeleporter.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/teleport/random/RandomTeleporter.java
@@ -53,6 +53,9 @@ public class RandomTeleporter {
         }
         for (Homes homes : basicsModule.getHomeManager().getAllHomes()) {
             for (Home home : homes.getHomes()) {
+                if (!location.getWorld().equals(home.getLocation().getWorld())) {
+                    continue;
+                }
                 if (Math.max(Math.abs(home.getLocation().getBlockX() - location.getBlockX()), Math.abs(home.getLocation().getBlockZ() - location.getBlockZ())) < MIN_DISTANCE_FROM_HOME) {
                     return CompletableFuture.completedFuture(null);
                 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -97,6 +97,8 @@ permissions:
     description: "Access to the /setspawn command."
   nabsuite.command.rtp:
     description: "Access to the /rtp command."
+  nabsuite.command.rtp.status:
+    description: "Access to the /rtp status command."
   nabsuite.command.channel:
     description: "Access to the /channel command."
   nabsuite.command.channel.create:

--- a/src/main/resources/resources/basics/config-patches/4.patch
+++ b/src/main/resources/resources/basics/config-patches/4.patch
@@ -1,0 +1,14 @@
+[add-field]
+key=random-teleport.world-settings.default.exclude-biomes
+value=\n      - "ocean"\n      - "frozen_ocean"\n      - "deep_ocean"\n      - "warm_ocean"\n      - "lukewarm_ocean"\n      - "cold_ocean"\n      - "deep_lukewarm_ocean"\n      - "deep_cold_ocean"\n      - "deep_frozen_ocean"
+comment=# Prevent random teleport from selecting one of these biomes
+
+[add-field]
+key=random-teleport.world-settings.default.pregenerate-max
+value=100
+comment=# Pregenerate this amount of random locations (0 to disable)
+
+[add-field]
+key=random-teleport.world-settings.default.pregenerate-interval
+value=100
+comment=# Interval (in ticks) between attempts to pregenerate a new location

--- a/src/main/resources/resources/basics/config.yml
+++ b/src/main/resources/resources/basics/config.yml
@@ -1,5 +1,5 @@
 # Don't edit this.
-version: 4
+version: 5
 
 # The highest number to check when testing a player's permissions for the maximum number of homes they can set.
 max-home-permission-check: 3
@@ -100,3 +100,21 @@ random-teleport:
 
       # At least how far away on the z-axis should the random teleport be from the centre?
       exclusion-radius-z: 1500
+
+      # Prevent random teleport from selecting one of these biomes
+      exclude-biomes:
+        - "ocean"
+        - "frozen_ocean"
+        - "deep_ocean"
+        - "warm_ocean"
+        - "lukewarm_ocean"
+        - "cold_ocean"
+        - "deep_lukewarm_ocean"
+        - "deep_cold_ocean"
+        - "deep_frozen_ocean"
+
+      # Pregenerate this amount of random locations (0 to disable)
+      pregenerate-max: 100
+
+      # Interval (in ticks) between attempts to pregenerate a new location
+      pregenerate-interval: 100


### PR DESCRIPTION
Added:
* Configurable list of biomes to exclude from RTP
* Pre-generate random locations to speed up RTP and decrease failure rate
* New command `/rtp status` (permission `nabsuite.command.rtp.status`) to display pre-generation status

Fixes:
* When testing if there is a home near a random location - the worlds were previously not compared
