### PR TITLE
Customize player nametag and tablist entry

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/basics/BasicsModule.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/BasicsModule.java
@@ -10,6 +10,7 @@ import com.froobworld.nabsuite.modules.basics.help.HelpManager;
 import com.froobworld.nabsuite.modules.basics.message.MessageCentre;
 import com.froobworld.nabsuite.modules.basics.motd.AnnouncementCentre;
 import com.froobworld.nabsuite.modules.basics.motd.MotdManager;
+import com.froobworld.nabsuite.modules.basics.nametag.NameTagManager;
 import com.froobworld.nabsuite.modules.basics.permissions.GroupManager;
 import com.froobworld.nabsuite.modules.basics.player.PlayerDataManager;
 import com.froobworld.nabsuite.modules.basics.player.mail.MailCentre;
@@ -42,6 +43,7 @@ public class BasicsModule extends NabModule {
     private SpawnManager spawnManager;
     private RandomTeleportManager randomTeleportManager;
     private ChatChannelManager chatChannelManager;
+    private NameTagManager nameTagManager;
 
     public BasicsModule(NabSuite nabSuite) {
         super(nabSuite, "basics");
@@ -74,6 +76,7 @@ public class BasicsModule extends NabModule {
         new AnnouncementCentre(this);
         randomTeleportManager = new RandomTeleportManager(this);
         chatChannelManager = new ChatChannelManager(this);
+        nameTagManager = new NameTagManager(this);
 
         Lists.newArrayList(
                 new MessageCommand(this),
@@ -129,6 +132,7 @@ public class BasicsModule extends NabModule {
     @Override
     public void postModulesEnable() {
         groupManager.postStartup();
+        nameTagManager.postStartup();
     }
 
     @Override
@@ -203,5 +207,9 @@ public class BasicsModule extends NabModule {
 
     public ChatChannelManager getChatChannelManager() {
         return chatChannelManager;
+    }
+
+    public NameTagManager getNameTagManager() {
+        return nameTagManager;
     }
 }

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/config/BasicsConfig.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/config/BasicsConfig.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.function.Function;
 
 public class BasicsConfig extends NabConfiguration {
-    private static final int CONFIG_VERSION = 5;
+    private static final int CONFIG_VERSION = 6;
 
     public BasicsConfig(BasicsModule basicsModule) {
         super(
@@ -141,6 +141,29 @@ public class BasicsConfig extends NabConfiguration {
             @Entry(key = "pregenerate-interval")
             public final ConfigEntry<Integer> pregenerateInterval = ConfigEntries.integerEntry();
 
+        }
+
+    }
+
+    @SectionMap(key = "name-tag", defaultKey = "default")
+    public ConfigSectionMap<String, NameTagSettings> nameTag = new ConfigSectionMap<>(s -> s, NameTagSettings.class,  true);
+
+    public static class NameTagSettings extends ConfigSection {
+
+        @Entry(key = "priority")
+        public final ConfigEntry<Integer> priority = ConfigEntries.integerEntry();
+
+        @Entry(key = "prefix")
+        public final ConfigEntry<String> prefix = new ConfigEntry<>();
+
+        @Entry(key = "suffix")
+        public final ConfigEntry<String> suffix = new ConfigEntry<>();
+
+        @Entry(key = "color")
+        public final ConfigEntry<String> color = new ConfigEntry<>();
+
+        public boolean isEmpty() {
+            return prefix.get().isEmpty() && suffix.get().isEmpty() && color.get().isEmpty();
         }
 
     }

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/nametag/NameTagFeature.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/nametag/NameTagFeature.java
@@ -1,0 +1,68 @@
+package com.froobworld.nabsuite.modules.basics.nametag;
+
+import com.froobworld.nabsuite.modules.basics.config.BasicsConfig;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Team;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Comparator;
+
+public class NameTagFeature implements Comparable<NameTagFeature> {
+    public interface Handler {
+        boolean isNameTagFeatureActive(Player player);
+    }
+
+    private final String name;
+    private final Component prefix;
+    private final Component suffix;
+    private final NamedTextColor color;
+    private final int priority;
+
+    private final Handler handler;
+
+    public NameTagFeature(String name, Handler handler, BasicsConfig.NameTagSettings config) {
+        this.name = name;
+        this.handler = handler;
+
+        priority = config.priority.get();
+        prefix = MiniMessage.miniMessage().deserialize(config.prefix.get());
+        suffix = MiniMessage.miniMessage().deserialize(config.suffix.get());
+        color = NamedTextColor.NAMES.value(config.color.get().toLowerCase());
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setupTeam(Team team) {
+        team.prefix(team.prefix().append(prefix));
+        team.suffix(team.suffix().append(suffix));
+        if (color != null) {
+            team.color(color);
+        }
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public boolean hasPermission(Player player) {
+        return player.hasPermission("nabsuite.nametag."+getName());
+    }
+
+    public boolean testPlayer(Player player) {
+        return handler.isNameTagFeatureActive(player);
+    }
+
+    @Override
+    public int compareTo(@NotNull NameTagFeature other) {
+        if (getPriority() == other.getPriority()) {
+            return Comparator.comparing(NameTagFeature::getName).compare(this, other);
+        }
+        return getPriority() - other.getPriority();
+    }
+
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/nametag/NameTagManager.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/nametag/NameTagManager.java
@@ -1,0 +1,157 @@
+package com.froobworld.nabsuite.modules.basics.nametag;
+
+import com.froobworld.nabsuite.modules.admin.AdminModule;
+import com.froobworld.nabsuite.modules.admin.punishment.PunishmentManager;
+import com.froobworld.nabsuite.modules.admin.vanish.VanishManager;
+import com.froobworld.nabsuite.modules.basics.BasicsModule;
+import com.froobworld.nabsuite.modules.basics.afk.AfkManager;
+import com.froobworld.nabsuite.modules.basics.config.BasicsConfig;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.Team;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class NameTagManager implements Listener {
+    private final BasicsModule basicsModule;
+    private final List<NameTagFeature> features = new LinkedList<>();
+    private NameTagFeature vanishFeature;
+
+    public NameTagManager(BasicsModule basicsModule) {
+        this.basicsModule = basicsModule;
+        Bukkit.getPluginManager().registerEvents(this, basicsModule.getPlugin());
+        // Update scoreboards every 3 seconds
+        Bukkit.getScheduler().scheduleSyncRepeatingTask(basicsModule.getPlugin(), this::loop, 30L, 60L);
+    }
+
+    public void postStartup() {
+        AfkManager afkManager = basicsModule.getAfkManager();
+        registerFeature("afk", afkManager::isAfk);
+
+        PunishmentManager punishmentManager = basicsModule.getPlugin().getModule(AdminModule.class).getPunishmentManager();
+        registerFeature("jailed", p -> punishmentManager.getPunishments(p.getUniqueId()).getJailPunishment() != null);
+        registerFeature("muted", p -> punishmentManager.getPunishments(p.getUniqueId()).getMutePunishment() != null);
+        registerFeature("restricted", p -> punishmentManager.getPunishments(p.getUniqueId()).getRestrictionPunishment() != null);
+
+        VanishManager vanishManager = basicsModule.getPlugin().getModule(AdminModule.class).getVanishManager();
+        vanishFeature = registerFeature("vanished", vanishManager::isVanished);
+    }
+
+    public NameTagFeature registerFeature(String name, NameTagFeature.Handler handler) {
+        BasicsConfig.NameTagSettings featureConfig = basicsModule.getConfig().nameTag.of(name);
+        if (!featureConfig.isEmpty()) {
+            NameTagFeature feature = new NameTagFeature(name, handler, featureConfig);
+            features.add(feature);
+            return feature;
+        }
+        return null;
+    }
+
+    private void loop() {
+        Map<Player,Set<NameTagFeature>> features = getPlayerFeatures();
+        Bukkit.getOnlinePlayers().forEach(player -> updatePlayerScoreboard(player, features));
+    }
+
+    private Map<Player,Set<NameTagFeature>> getPlayerFeatures() {
+        Map<Player,Set<NameTagFeature>> playerFeatures = new HashMap<>();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            playerFeatures.put(player, features.stream().filter(feature -> feature.testPlayer(player)).collect(Collectors.toSet()));
+        }
+        return playerFeatures;
+    }
+
+    private Team getEveryoneTeam(Scoreboard scoreboard) {
+        Team team = scoreboard.getTeam("everyone");
+        if (team == null) {
+            team = scoreboard.registerNewTeam("everyone");
+            team.setCanSeeFriendlyInvisibles(true);
+            team.setAllowFriendlyFire(true);
+            team.setOption(Team.Option.COLLISION_RULE, Team.OptionStatus.NEVER);
+        }
+        return team;
+    }
+
+    private void updatePlayerScoreboard(Player player, Map<Player,Set<NameTagFeature>> playerFeatures) {
+        Scoreboard scoreboard = player.getScoreboard();
+        if (scoreboard.equals(Bukkit.getScoreboardManager().getMainScoreboard())) {
+            return;
+        }
+
+        boolean isVanished = basicsModule.getPlugin().getModule(AdminModule.class).getVanishManager().isVanished(player);
+        Team teamEveryone = isVanished ? getEveryoneTeam(scoreboard) : null;
+
+        playerFeatures.forEach((target, featureSet) -> {
+            // Filter out any features the player isn't allowed to see
+            featureSet = featureSet.stream()
+                    .filter(feature -> feature.hasPermission(player))
+                    .collect(Collectors.toSet());
+
+            if (!player.equals(target) && featureSet.contains(vanishFeature)) {
+                // Target is vanished, put in own team
+                Team team = scoreboard.getTeam("vanished");
+                if (team == null) {
+                    team = scoreboard.registerNewTeam("vanished");
+                    team.setCanSeeFriendlyInvisibles(true);
+                    team.setAllowFriendlyFire(true);
+                    team.setOption(Team.Option.COLLISION_RULE, Team.OptionStatus.NEVER);
+                    vanishFeature.setupTeam(team);
+                }
+                team.addPlayer(target);
+            } else if (isVanished) {
+                // Player is vanished, put everyone in same team
+                teamEveryone.addPlayer(target);
+            } else if (featureSet.isEmpty()) {
+                // Target has no features, remove from current team
+                Team current = scoreboard.getPlayerTeam(target);
+                if (current != null) {
+                    current.removePlayer(target);
+                }
+            } else {
+                // Calculate team from features and add target
+                // example team name with multiple features: "afk_muted_restricted"
+                String teamName = featureSet.stream().map(NameTagFeature::getName).collect(Collectors.joining("_"));
+                Team team = scoreboard.getTeam(teamName);
+                if (team == null) {
+                    team = scoreboard.registerNewTeam(teamName);
+                    team.setCanSeeFriendlyInvisibles(false);
+                    team.setAllowFriendlyFire(true);
+                    for (NameTagFeature feature : featureSet) {
+                        feature.setupTeam(team);
+                    }
+                }
+                team.addPlayer(target);
+            }
+        });
+
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        Set<NameTagFeature> playerFeatures = features.stream()
+                .filter(feature -> feature.hasPermission(player))
+                .collect(Collectors.toSet());
+        if (!playerFeatures.isEmpty() || player.hasPermission(VanishManager.VANISH_PERMISSION)) {
+            // Create per-player scoreboard
+            player.setScoreboard(Bukkit.getScoreboardManager().getNewScoreboard());
+            updatePlayerScoreboard(player, getPlayerFeatures());
+        }
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        Bukkit.getOnlinePlayers().forEach(p -> {
+            Team current = p.getScoreboard().getPlayerTeam(player);
+            if (current != null) {
+                current.removePlayer(player);
+            }
+        });
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -152,6 +152,18 @@ permissions:
   nabsuite.command.channels:
     description: "Access to the /channels command."
 
+  # Basics module name tags
+  nabsuite.nametag.afk:
+    description: "Show AFK tag in tab list and name tag"
+  nabsuite.nametag.jailed:
+    description: "Show jailed tag in tab list and name tag"
+  nabsuite.nametag.muted:
+    description: "Show muted tag in tab list and name tag"
+  nabsuite.nametag.restricted:
+    description: "Show restricted tag in tab list and name tag"
+  nabsuite.nametag.vanished:
+    description: "Show vanished tag in tab list and name tag"
+
   # Basics module other permissions
   nabsuite.teleport.all:
     description: "Provides the ability to teleport to all players."

--- a/src/main/resources/resources/basics/config-patches/5.patch
+++ b/src/main/resources/resources/basics/config-patches/5.patch
@@ -1,0 +1,71 @@
+[add-section]
+key=name-tag
+comment=# Name tag settings
+
+[add-section]
+key=name-tag.default
+comment=# Defaults for name tag
+
+[add-field]
+key=name-tag.default.priority
+value=5
+comment=# Priority, higher is applied last
+
+[add-field]
+key=name-tag.default.prefix
+value=""
+comment=# Name tag prefix
+
+[add-field]
+key=name-tag.default.suffix
+value=""
+comment=# Name tag suffix
+
+[add-field]
+key=name-tag.default.color
+value=""
+comment=# Name tag color
+
+[add-section]
+key=name-tag.afk
+comment=# Settings for AFK name tag
+
+[add-field]
+key=name-tag.afk.color
+value=gray
+
+[add-section]
+key=name-tag.muted
+comment=# Settings for muted name tag
+
+[add-field]
+key=name-tag.muted.suffix
+value=" <red>🔇</red>"
+
+[add-section]
+key=name-tag.restricted
+comment=# Settings for restricted name tag
+
+[add-field]
+key=name-tag.restricted.suffix
+value=" <gold>⛓</gold>"
+
+[add-section]
+key=name-tag.jailed
+comment=# Settings for jailed name tag
+
+[add-field]
+key=name-tag.jailed.suffix
+value=" <yellow>🔒</yellow>"
+
+[add-section]
+key=name-tag.vanished
+comment=# Settings for vanished name tag
+
+[add-field]
+key=name-tag.vanished.priority
+value=10
+
+[add-field]
+key=name-tag.vanished.suffix
+value=" <yellow>(vanished)</yellow>"

--- a/src/main/resources/resources/basics/config.yml
+++ b/src/main/resources/resources/basics/config.yml
@@ -1,5 +1,5 @@
 # Don't edit this.
-version: 5
+version: 6
 
 # The highest number to check when testing a player's permissions for the maximum number of homes they can set.
 max-home-permission-check: 3
@@ -118,3 +118,42 @@ random-teleport:
 
       # Interval (in ticks) between attempts to pregenerate a new location
       pregenerate-interval: 100
+
+# Name tag settings
+name-tag:
+  # Defaults for name tag
+  default:
+    # Priority, higher is applied last
+    priority: 5
+
+    # Name tag prefix
+    prefix: ""
+
+    # Name tag suffix
+    suffix: ""
+
+    # Name tag color
+    color: ""
+
+  # Settings for AFK name tag
+  afk:
+    color: gray
+
+  # Settings for muted name tag
+  muted:
+    suffix: " <red>🔇</red>"
+
+  # Settings for restricted name tag
+  restricted:
+    suffix: " <gold>⛓</gold>"
+
+  # Settings for jailed name tag
+  jailed:
+    suffix: " <yellow>🔒</yellow>"
+
+  # Settings for vanished name tag
+  vanished:
+    priority: 10
+
+    suffix: " <yellow>(vanished)</yellow>"
+


### PR DESCRIPTION
Adds configurable prefix, suffix and color based on active features/punishments:
- AFK (default gray name)
- Jailed (default suffixed with yellow padlock)
- Muted (default suffixed with red mute icon)
- Restricted (default suffixed with gold chains icon)
- Vanished (default suffixed with `(vanished)` in yellow)

Which features are visible for a player is controlled by these new permissions:
- nabsuite.nametag.afk
- nabsuite.nametag.jailed
- nabsuite.nametag.muted
- nabsuite.nametag.restricted
- nabsuite.nametag.vanished

To disable one of the categories, either remove it from the config or remove the permission

Example with all nametags active at once:

![2024-12-20_04 25 35](https://github.com/user-attachments/assets/c2fad782-d62a-4ac7-8a5d-ec71409eae7b)
