### PR TITLE
Compatability for 1.21.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Install NabConfiguration
         run: ./gradlew install
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: 17
-          distribution: 'adopt'
+          java-version: 21
+          distribution: 'temurin'
 
       - name: Check out NabSuite
         uses: actions/checkout@v2

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ processResources {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-    compileOnly 'io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT'
+    compileOnly 'io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT'
     compileOnly 'net.luckperms:api:5.4'
     compileOnly 'us.dynmap:DynmapCoreAPI:3.3'
     compileOnly 'us.dynmap:dynmap-api:3.3'

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/teleport/random/RandomTeleporter.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/teleport/random/RandomTeleporter.java
@@ -8,8 +8,8 @@ import com.froobworld.nabsuite.modules.protect.ProtectModule;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
-import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 
 import java.util.HashMap;
@@ -17,7 +17,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
@@ -30,7 +29,7 @@ public class RandomTeleporter {
     private static final double MIN_DISTANCE_FROM_HOME = 300;
     private final BasicsModule basicsModule;
     private final Map<World, Queue<Location>> pregenerated = new HashMap<>();
-    private final Map<World, Set<Biome>> excludeBiomes = new HashMap<>();
+    private final Map<World, Set<NamespacedKey>> excludeBiomes = new HashMap<>();
 
     public RandomTeleporter(BasicsModule basicsModule) {
         this.basicsModule = basicsModule;
@@ -49,16 +48,7 @@ public class RandomTeleporter {
             excludeBiomes.put(world, new HashSet<>(
                     worldSettings.excludeBiomes.get()
                             .stream()
-                            .map(name -> {
-                                for (Biome biome: Biome.values()) {
-                                    if (biome.name().equalsIgnoreCase(name.trim())) {
-                                        return biome;
-                                    }
-                                }
-                                basicsModule.getPlugin().getSLF4JLogger().warn("RandomTeleporter unknown biome in exclude-biomes: " + name);
-                                return null;
-                            })
-                            .filter(Objects::nonNull)
+                            .map(name -> NamespacedKey.fromString(name.toLowerCase().trim()))
                             .toList())
             );
 
@@ -125,7 +115,7 @@ public class RandomTeleporter {
                 .thenCompose(chunk -> {
                     if (chunk != null) {
                         Block block = location.getWorld().getHighestBlockAt(location);
-                        if (excludeBiomes.containsKey(location.getWorld()) && excludeBiomes.get(location.getWorld()).contains(block.getBiome())) {
+                        if (excludeBiomes.containsKey(location.getWorld()) && excludeBiomes.get(location.getWorld()).contains(block.getBiome().getKey())) {
                             return CompletableFuture.completedFuture(null);
                         }
                         if (block.isSolid()) {

--- a/src/main/java/com/froobworld/nabsuite/modules/mechs/trees/TreeReplanter.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/mechs/trees/TreeReplanter.java
@@ -4,7 +4,6 @@ import com.froobworld.nabsuite.modules.mechs.MechsModule;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
@@ -15,7 +14,6 @@ import org.bukkit.event.block.BlockBreakEvent;
 public class TreeReplanter implements Listener {
     private final MechsModule mechsModule;
     private final TreeManager treeManager;
-    private final Tag<Material> PALE_OAK_LOGS = Bukkit.getTag(Tag.REGISTRY_BLOCKS, NamespacedKey.minecraft("pale_oak_logs"), Material.class);
 
     public TreeReplanter(MechsModule mechsModule, TreeManager treeManager) {
         this.mechsModule = mechsModule;
@@ -64,8 +62,8 @@ public class TreeReplanter implements Listener {
             return Material.JUNGLE_SAPLING;
         } else if (Tag.CHERRY_LOGS.isTagged(woodType)) {
             return Material.CHERRY_SAPLING;
-        } else if (PALE_OAK_LOGS != null && PALE_OAK_LOGS.isTagged(woodType)) {
-            return Material.getMaterial("PALE_OAK_SAPLING");
+        } else if (Tag.PALE_OAK_LOGS.isTagged(woodType)) {
+            return Material.PALE_OAK_SAPLING;
         }
         return null;
     }

--- a/src/main/java/com/froobworld/nabsuite/modules/mechs/trees/TreeReplanter.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/mechs/trees/TreeReplanter.java
@@ -4,6 +4,7 @@ import com.froobworld.nabsuite.modules.mechs.MechsModule;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
@@ -14,6 +15,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 public class TreeReplanter implements Listener {
     private final MechsModule mechsModule;
     private final TreeManager treeManager;
+    private final Tag<Material> PALE_OAK_LOGS = Bukkit.getTag(Tag.REGISTRY_BLOCKS, NamespacedKey.minecraft("pale_oak_logs"), Material.class);
 
     public TreeReplanter(MechsModule mechsModule, TreeManager treeManager) {
         this.mechsModule = mechsModule;
@@ -62,6 +64,8 @@ public class TreeReplanter implements Listener {
             return Material.JUNGLE_SAPLING;
         } else if (Tag.CHERRY_LOGS.isTagged(woodType)) {
             return Material.CHERRY_SAPLING;
+        } else if (PALE_OAK_LOGS != null && PALE_OAK_LOGS.isTagged(woodType)) {
+            return Material.getMaterial("PALE_OAK_SAPLING");
         }
         return null;
     }

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/horse/HorseClaimEnforcer.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/horse/HorseClaimEnforcer.java
@@ -11,7 +11,7 @@ import org.bukkit.event.entity.PlayerLeashEntityEvent;
 import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerUnleashEntityEvent;
-import org.spigotmc.event.entity.EntityMountEvent;
+import org.bukkit.event.entity.EntityMountEvent;
 
 public class HorseClaimEnforcer implements Listener {
     private final HorseManager horseManager;

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/vehicle/VehicleTracker.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/vehicle/VehicleTracker.java
@@ -10,7 +10,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
-import org.spigotmc.event.entity.EntityMountEvent;
+import org.bukkit.event.entity.EntityMountEvent;
 
 public class VehicleTracker implements Listener {
     private final NamespacedKey pdcKey;


### PR DESCRIPTION
* Remove use of Biome.values() ([deprecated since 1.21.3](https://jd.papermc.io/paper/1.21.3/org/bukkit/block/Biome.html#values()))
* Change package for EntityMountEvent ([deprecated since 1.20.4](https://jd.papermc.io/paper/1.20.4/org/spigotmc/event/entity/EntityMountEvent.html))
* Add pale oak support to TreeReplanter (compatible with older versions)