### PR TITLE
Discord command bridge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     compileOnly 'net.luckperms:api:5.4'
     compileOnly 'us.dynmap:DynmapCoreAPI:3.3'
     compileOnly 'us.dynmap:dynmap-api:3.3'
+    implementation 'net.kyori:adventure-text-serializer-ansi:4.18.0'
     implementation 'cloud.commandframework:cloud-paper:1.6.2'
     implementation ('cloud.commandframework:cloud-minecraft-extras:1.6.2') {
         exclude group: 'net.kyori'
@@ -72,6 +73,7 @@ shadowJar {
     relocate 'org.intellij.lang', 'com.froobworld.nabsuite.lib.intellijlang'
     relocate 'org.jetbrains.annotations', 'com.froobworld.nabsuite.lib.jetbrainsannotations'
     relocate 'org.json', 'com.froobworld.nabsuite.lib.json'
+    relocate 'net.kyori.adventure.text.serializer.ansi', 'com.froobworld.nabsuite.lib.ansiserializer'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     }
     implementation 'com.froobworld:nab-configuration:1.0.2'
     implementation 'org.jooq:joor-java-8:0.9.14'
-    implementation ('net.dv8tion:JDA:4.3.0_333') {
+    implementation ('net.dv8tion:JDA:5.3.0') {
         exclude module: 'opus-java'
         exclude module: 'lavaplayer'
         exclude group: 'org.slf4j'

--- a/src/main/java/com/froobworld/nabsuite/modules/admin/notification/DiscordStaffLog.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/admin/notification/DiscordStaffLog.java
@@ -13,7 +13,7 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
+import org.bukkit.OfflinePlayer;
 
 import java.awt.*;
 import java.util.UUID;
@@ -90,7 +90,7 @@ public class DiscordStaffLog {
 
         TextChannel channel = discordModule.getDiscordBot().getStaffLogChannel();
         if (channel != null) {
-            String resolverName = resolver instanceof Player ? resolver.getName() : "Console";
+            String resolverName = resolver instanceof OfflinePlayer ? resolver.getName() : "Console";
 
             EmbedBuilder embedBuilder = new EmbedBuilder().setTitle("Ticket closed")
                     .setColor(Color.GREEN)
@@ -128,7 +128,7 @@ public class DiscordStaffLog {
 
         TextChannel channel = discordModule.getDiscordBot().getStaffLogChannel();
         if (channel != null) {
-            String handlerName = handler instanceof Player ? handler.getName() : "Console";
+            String handlerName = handler instanceof OfflinePlayer ? handler.getName() : "Console";
 
             EmbedBuilder embedBuilder = new EmbedBuilder().setTitle("Area request " + (approved ? "approved" : "denied"))
                     .setColor(approved ? Color.GREEN : Color.RED)

--- a/src/main/java/com/froobworld/nabsuite/modules/admin/notification/DiscordStaffLog.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/admin/notification/DiscordStaffLog.java
@@ -11,7 +11,7 @@ import com.froobworld.nabsuite.util.ConsoleUtils;
 import com.froobworld.nabsuite.util.DurationDisplayer;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/command/FirstJoinCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/command/FirstJoinCommand.java
@@ -12,6 +12,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.CommandSender;
+import com.froobworld.nabsuite.modules.discord.bot.command.DiscordCommandSender;
 
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -35,6 +36,13 @@ public class FirstJoinCommand extends NabCommand {
     public void execute(CommandContext<CommandSender> context) {
         PlayerIdentity playerIdentity = context.get("player");
         PlayerData playerData = basicsModule.getPlayerDataManager().getPlayerData(playerIdentity.getUuid());
+        if (context.getSender() instanceof DiscordCommandSender discordSender) {
+            // Send as discord timestamp
+            discordSender.updateResponse(msg -> msg.editOriginal(
+                playerIdentity.getLastName() + " joined <t:"+(playerData.getFirstJoined()/1000)+":R>."
+            ));
+            return;
+        }
         long timeSinceFirstJoin = System.currentTimeMillis() - playerData.getFirstJoined();
 
         String joinDate = new SimpleDateFormat("dd MMMM yyyy").format(Date.from(Instant.ofEpochMilli(playerData.getFirstJoined())));

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/command/SeenCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/command/SeenCommand.java
@@ -7,6 +7,7 @@ import com.froobworld.nabsuite.command.argument.arguments.PlayerIdentityArgument
 import com.froobworld.nabsuite.data.identity.PlayerIdentity;
 import com.froobworld.nabsuite.modules.basics.BasicsModule;
 import com.froobworld.nabsuite.modules.basics.player.PlayerData;
+import com.froobworld.nabsuite.modules.discord.bot.command.DiscordCommandSender;
 import com.froobworld.nabsuite.util.DurationDisplayer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
@@ -40,6 +41,14 @@ public class SeenCommand extends NabCommand {
                     Component.text("That player is online right now, silly.").color(NamedTextColor.YELLOW)
             );
         } else {
+            if (context.getSender() instanceof DiscordCommandSender discordSender) {
+                // Send as discord timestamp
+                discordSender.updateResponse(msg -> msg.editOriginal(
+                    playerIdentity.getLastName() + " last played <t:"+(playerData.getLastPlayed()/1000)+":R>."
+                ));
+                return;
+            }
+
             String lastSeenDate = new SimpleDateFormat("dd MMMM yyyy").format(Date.from(Instant.ofEpochMilli(playerData.getLastPlayed())));
 
             context.getSender().sendMessage(

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/bot/DiscordBot.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/bot/DiscordBot.java
@@ -90,6 +90,9 @@ public class DiscordBot {
             chatBridge.shutdown();
             accountLinkManager.shutdown();
             jda.shutdown();
+            if (chatWebhook != null) {
+                chatWebhook.delete().submit(true).join();
+            }
         }
     }
 

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/bot/DiscordBot.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/bot/DiscordBot.java
@@ -9,7 +9,7 @@ import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import org.bukkit.Bukkit;
 
@@ -36,7 +36,7 @@ public class DiscordBot {
         if (jda == null) {
             try {
                 jda = JDABuilder.createDefault(discordModule.getDiscordConfig().botToken.get())
-                        .enableIntents(GatewayIntent.GUILD_MESSAGES)
+                        .enableIntents(GatewayIntent.GUILD_MESSAGES, GatewayIntent.MESSAGE_CONTENT)
                         .build();
             } catch (Exception exception) {
                 discordModule.getPlugin().getSLF4JLogger().warn("Failed to start Discord bot, retrying in 30 seconds.");

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/bot/DiscordBot.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/bot/DiscordBot.java
@@ -1,6 +1,7 @@
 package com.froobworld.nabsuite.modules.discord.bot;
 
 import com.froobworld.nabsuite.modules.discord.DiscordModule;
+import com.froobworld.nabsuite.modules.discord.bot.command.DiscordCommandBridge;
 import com.froobworld.nabsuite.modules.discord.bot.chat.ChatBridge;
 import com.froobworld.nabsuite.modules.discord.bot.linking.AccountLinkManager;
 import com.froobworld.nabsuite.modules.discord.bot.syncer.DiscordSyncer;
@@ -20,6 +21,7 @@ public class DiscordBot {
     private AccountLinkManager accountLinkManager;
     private ChatBridge chatBridge;
     private DiscordSyncer discordSyncer;
+    private DiscordCommandBridge commandBridge;
     private JDA jda;
 
     public DiscordBot(DiscordModule discordModule) throws LoginException {
@@ -51,6 +53,7 @@ public class DiscordBot {
                 accountLinkManager = new AccountLinkManager(discordModule);
                 chatBridge = new ChatBridge(discordModule);
                 discordSyncer = new DiscordSyncer(discordModule);
+                commandBridge = new DiscordCommandBridge(discordModule, accountLinkManager);
             });
         }
     }

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/bot/chat/Discord2MinecraftBridge.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/bot/chat/Discord2MinecraftBridge.java
@@ -9,7 +9,7 @@ import com.froobworld.nabsuite.util.ComponentUtils;
 import com.vdurmont.emoji.EmojiParser;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
@@ -32,11 +32,11 @@ public class Discord2MinecraftBridge extends ListenerAdapter {
     }
 
     @Override
-    public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
+    public void onMessageReceived(MessageReceivedEvent event) {
         if (event.getAuthor().isBot() || event.isWebhookMessage()) {
             return;
         }
-        if (!event.getChannel().equals(discordModule.getDiscordBot().getChatChannel())) {
+        if (!event.isFromGuild() || !event.getChannel().equals(discordModule.getDiscordBot().getChatChannel())) {
             return;
         }
         if (event.getMessage().getContentRaw().equalsIgnoreCase("playerlist")) {

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/bot/chat/Minecraft2DiscordBridge.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/bot/chat/Minecraft2DiscordBridge.java
@@ -75,7 +75,7 @@ public class Minecraft2DiscordBridge implements Listener {
             // Prefer webhook
             webhook.sendMessage(DiscordUtils.escapeMarkdown(PlainTextComponentSerializer.plainText().serialize(event.message())))
                     .setUsername(event.getPlayer().getName())
-                    .setAvatarUrl(DiscordUtils.getAvatarUrl(event.getPlayer().getUniqueId(), 64))
+                    .setAvatarUrl(DiscordUtils.getHeadUrl(event.getPlayer().getUniqueId(), 128))
                     .setAllowedMentions(Collections.emptySet())
                     .queue();
         } else {

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/bot/chat/Minecraft2DiscordBridge.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/bot/chat/Minecraft2DiscordBridge.java
@@ -4,7 +4,7 @@ import com.froobworld.nabsuite.modules.discord.DiscordModule;
 import com.froobworld.nabsuite.modules.discord.utils.DiscordUtils;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.exceptions.RateLimitedException;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
@@ -75,7 +75,7 @@ public class Minecraft2DiscordBridge implements Listener {
                 .replace("<message>", PlainTextComponentSerializer.plainText().serialize(event.message()));
 
         channel.sendMessage(DiscordUtils.escapeMarkdown(messageText))
-                .allowedMentions(Collections.emptySet())
+                .setAllowedMentions(Collections.emptySet())
                 .queue();
     }
 

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/bot/command/DiscordCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/bot/command/DiscordCommand.java
@@ -1,0 +1,196 @@
+package com.froobworld.nabsuite.modules.discord.bot.command;
+
+import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.StaticArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.meta.CommandMeta;
+import com.froobworld.nabsuite.command.argument.arguments.StringArgument;
+import com.froobworld.nabsuite.modules.admin.command.argument.JailArgument;
+import com.froobworld.nabsuite.modules.discord.config.DiscordConfig;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.AutoCompleteQuery;
+import net.dv8tion.jda.api.interactions.IntegrationType;
+import net.dv8tion.jda.api.interactions.InteractionContextType;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.CommandData;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+import net.dv8tion.jda.internal.interactions.CommandDataImpl;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+
+public class DiscordCommand {
+
+    interface OptionGetter {
+        OptionMapping getOption(@Nonnull String name);
+    }
+
+    protected final String commandName;
+    protected final String description;
+    protected final DiscordCommandBridge bridge;
+    protected final DiscordConfig.CommandSettings config;
+    protected final Map<String, DiscordCommand> subCommands = new HashMap<>();
+    protected cloud.commandframework.Command<CommandSender> cloudCommand;
+
+    public DiscordCommand(DiscordCommandBridge bridge, String name, DiscordConfig.CommandSettings settings, cloud.commandframework.Command<CommandSender> command) {
+        this(bridge, name, settings, command.getCommandMeta().getOrDefault(CommandMeta.DESCRIPTION, ""));
+        this.cloudCommand = command;
+    }
+
+    public DiscordCommand(DiscordCommandBridge bridge, String command, DiscordConfig.CommandSettings settings, String description) {
+        this.bridge = bridge;
+        this.commandName = command;
+        this.description = description != null && !description.isEmpty() ? description : commandName;
+        this.config = settings;
+    }
+
+    public String getName() {
+        return commandName;
+    }
+
+    public boolean isEphemeral() {
+        return config == null || !config.publicReply.get();
+    }
+
+    public void addSubCommand(String name, DiscordCommand command) {
+        subCommands.put(name, command);
+    }
+
+    public DiscordCommand getSubCommand(String name) {
+        return subCommands.get(name);
+    }
+
+    public CommandData getCommandData(String name) {
+        CommandDataImpl data = new CommandDataImpl(name, description);
+        data.setContexts(EnumSet.of(InteractionContextType.GUILD))
+                .setIntegrationTypes(EnumSet.of(IntegrationType.GUILD_INSTALL))
+                .setGuildOnly(true)
+                .setDefaultPermissions(DefaultMemberPermissions.DISABLED);
+
+        data.addSubcommands(subCommands.entrySet().stream()
+                .map(sub -> sub.getValue().getSubcommandData(sub.getKey()))
+                .toList());
+
+        if (data.getSubcommands().isEmpty()) {
+            if (cloudCommand != null) {
+                data.addOptions(cloudCommand.getArguments()
+                        .stream()
+                        .filter(a -> !a.getClass().isAssignableFrom(StaticArgument.class))
+                        .map(this::buildOption)
+                        .toList());
+            } else {
+                data.addOption(OptionType.STRING, "arguments", "arguments", false, true);
+            }
+        }
+        return data;
+    }
+
+    private SubcommandData getSubcommandData(String name) {
+        SubcommandData data = new SubcommandData(name, description);
+        if (cloudCommand != null) {
+            data.addOptions(cloudCommand.getArguments()
+                    .stream()
+                    .filter(a -> !a.getClass().isAssignableFrom(StaticArgument.class))
+                    .map(this::buildOption)
+                    .toList());
+        } else {
+            data.addOption(OptionType.STRING, "arguments", "arguments", false, true);
+        }
+        return data;
+    }
+
+    private OptionData buildOption(CommandArgument<CommandSender, ?> arg) {
+        OptionData data = new OptionData(OptionType.STRING, arg.getName(), arg.getName(), arg.isRequired(), true);
+
+        if (JailArgument.class.equals(arg.getClass())) {
+            // List of jails doesn't change often enough for dynamic autocomplete.
+            // Update command with all available options once on startup
+            data.setAutoComplete(false)
+                    .addChoices(
+                            arg.getSuggestionsProvider().apply(new CommandContext<>(Bukkit.getConsoleSender(), bridge.discordModule.getPlugin().getCommandManager()), "")
+                                    .stream()
+                                    .map(value -> new Command.Choice(value, value))
+                                    .toList()
+                    );
+        } else if (StringArgument.class.equals(arg.getClass())) {
+            data.setAutoComplete(false);
+        }
+
+        return data;
+    }
+
+    private String getCommandLine(OptionGetter options) {
+        return getCommandLine(options, null, null);
+    }
+
+    private String getCommandLine(OptionGetter options, String currentField, String currentValue) {
+        StringBuilder cmd = new StringBuilder(commandName);
+        if (cloudCommand != null) {
+            for (CommandArgument<CommandSender, ?> arg : cloudCommand.getArguments()) {
+                if (arg.getClass().isAssignableFrom(StaticArgument.class)) {
+                    continue;
+                }
+                cmd.append(" ");
+                OptionMapping opt = options.getOption(arg.getName());
+                if (currentField != null && currentField.equals(arg.getName())) {
+                    cmd.append(currentValue);
+                    break;
+                }
+                if (opt != null && !opt.getAsString().isEmpty()) {
+                    cmd.append(opt.getAsString());
+                }
+            }
+        } else {
+            if (currentField != null && currentField.equals("arguments")) {
+                cmd.append(" ").append(currentValue);
+            } else {
+                OptionMapping opt = options.getOption("arguments");
+                if (opt != null && !opt.getAsString().isEmpty()) {
+                    cmd.append(" ").append(opt.getAsString());
+                }
+            }
+        }
+        return cmd.toString();
+    }
+
+    public void execute(@NotNull DiscordCommandSender sender, @NotNull SlashCommandInteractionEvent event) {
+        try {
+            String command = getCommandLine(event::getOption);
+            bridge.discordModule.getPlugin().getSLF4JLogger().info(
+                    "DiscordCommandBridge: {} issued server command: /{}",
+                    sender.getName(),
+                    command
+            );
+            Bukkit.dispatchCommand(sender, command);
+        } catch (Throwable e) {
+            sender.replyError(e.getMessage());
+        }
+    }
+
+    public void autocomplete(@NotNull DiscordCommandSender sender, @NotNull CommandAutoCompleteInteractionEvent event) {
+        try {
+            AutoCompleteQuery q = event.getFocusedOption();
+            String commandLine = getCommandLine(event::getOption, q.getName(), q.getValue());
+            List<String> suggestions = Bukkit.getCommandMap().tabComplete(sender, commandLine);
+            if (suggestions == null || suggestions.isEmpty()) {
+                event.replyChoices().queue();
+                return;
+            }
+            List<String> current = Arrays.stream(q.getValue().split(" ")).toList();
+            String prefix = current.size() == 1 ? "" : String.join(" ", current.subList(0, current.size() - 2));
+            event.replyChoices(suggestions.stream().map(s -> new Command.Choice(prefix + s, prefix + s)).toList()).queue();
+
+        } catch (Throwable e) {
+            event.replyChoices().queue();
+        }
+    }
+
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/bot/command/DiscordCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/bot/command/DiscordCommand.java
@@ -24,15 +24,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.*;
+import java.util.function.Function;
 
 public class DiscordCommand {
-
-    interface OptionGetter {
-        OptionMapping getOption(@Nonnull String name);
-    }
-
     protected final String commandName;
     protected final String description;
     protected final DiscordCommandBridge bridge;
@@ -127,11 +122,11 @@ public class DiscordCommand {
         return data;
     }
 
-    private String getCommandLine(OptionGetter options) {
+    private String getCommandLine(Function<String, OptionMapping> options) {
         return getCommandLine(options, null, null);
     }
 
-    private String getCommandLine(OptionGetter options, String currentField, String currentValue) {
+    private String getCommandLine(Function<String, OptionMapping> options, String currentField, String currentValue) {
         StringBuilder cmd = new StringBuilder(commandName);
         if (cloudCommand != null) {
             for (CommandArgument<CommandSender, ?> arg : cloudCommand.getArguments()) {
@@ -139,7 +134,7 @@ public class DiscordCommand {
                     continue;
                 }
                 cmd.append(" ");
-                OptionMapping opt = options.getOption(arg.getName());
+                OptionMapping opt = options.apply(arg.getName());
                 if (currentField != null && currentField.equals(arg.getName())) {
                     cmd.append(currentValue);
                     break;
@@ -152,7 +147,7 @@ public class DiscordCommand {
             if (currentField != null && currentField.equals("arguments")) {
                 cmd.append(" ").append(currentValue);
             } else {
-                OptionMapping opt = options.getOption("arguments");
+                OptionMapping opt = options.apply("arguments");
                 if (opt != null && !opt.getAsString().isEmpty()) {
                     cmd.append(" ").append(opt.getAsString());
                 }

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/bot/command/DiscordCommandBridge.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/bot/command/DiscordCommandBridge.java
@@ -1,0 +1,173 @@
+package com.froobworld.nabsuite.modules.discord.bot.command;
+
+import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.StaticArgument;
+import com.froobworld.nabsuite.data.identity.PlayerIdentity;
+import com.froobworld.nabsuite.modules.admin.AdminModule;
+import com.froobworld.nabsuite.modules.discord.DiscordModule;
+import com.froobworld.nabsuite.modules.discord.bot.linking.AccountLinkManager;
+import com.froobworld.nabsuite.modules.discord.config.DiscordConfig;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandMap;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class DiscordCommandBridge extends ListenerAdapter {
+
+    DiscordModule discordModule;
+    AdminModule adminModule;
+    AccountLinkManager accountLinkManager;
+    Map<String, DiscordCommand> commands = new HashMap<>();
+
+    public DiscordCommandBridge(DiscordModule discordModule, AccountLinkManager accountLinkManager) {
+        this.discordModule = discordModule;
+        this.accountLinkManager = accountLinkManager;
+        this.adminModule = discordModule.getPlugin().getModule(AdminModule.class);
+
+        syncCommands();
+        discordModule.getDiscordBot().getJda().addEventListener(this);
+    }
+
+    private void syncCommands() {
+        Map<String, cloud.commandframework.Command<CommandSender>> nabCommands = new HashMap<>();
+        for (cloud.commandframework.Command<CommandSender> command: discordModule.getPlugin().getCommandManager().getCommands()) {
+            String commandName = command.getArguments().stream()
+                    .filter(a -> StaticArgument.class.equals(a.getClass()))
+                    .map(CommandArgument::getName)
+                    .collect(Collectors.joining(" "));
+            nabCommands.put(commandName.toLowerCase(), command);
+        }
+
+        CommandMap bukkitCommands = Bukkit.getCommandMap();
+
+        DiscordConfig.Commands config = discordModule.getDiscordConfig().commands;
+
+        Map<String, DiscordCommand> commandMap = new HashMap<>();
+
+        for (String cmd: config.enabled.get()) {
+            DiscordConfig.CommandSettings settings = config.settings.of(cmd);
+            String overrideName = settings.overrideName.get().isEmpty() ? cmd : settings.overrideName.get();
+            String overrideMain = overrideName.contains(" ") ? overrideName.split(" ", 2)[0] : overrideName;
+            String overrideSub = overrideName.contains(" ") ? overrideName.split(" ", 2)[1] : null;
+            String mainCommand = cmd.contains(" ") ? cmd.split(" ", 2)[0] : cmd;
+
+            DiscordCommand command = null;
+            if (nabCommands.containsKey(cmd.toLowerCase())) {
+                command = new DiscordCommand(this, cmd, settings, nabCommands.get(cmd.toLowerCase()));
+            } else {
+                org.bukkit.command.Command bukkitCommand = bukkitCommands.getCommand(mainCommand);
+                if (bukkitCommand != null) {
+                    command = new DiscordCommand(this, cmd, settings, bukkitCommand.getDescription());
+                }
+            }
+
+            if (command == null) {
+                discordModule.getPlugin().getSLF4JLogger().error("DiscordCommandBridge: Command not found - {}", cmd);
+                continue;
+            }
+
+            DiscordCommand parent = commandMap.get(overrideMain);
+            if (overrideSub == null) {
+                if (parent != null) {
+                    discordModule.getPlugin().getSLF4JLogger().error("DiscordCommandBridge: Duplicate command or mixing of subcommands and commands - {}", cmd);
+                    continue;
+                }
+                commandMap.put(overrideMain, command);
+            } else {
+                if (parent == null) {
+                    parent = new DiscordCommand(this, overrideMain, null, overrideMain);
+                    commandMap.put(overrideMain, parent);
+                } else if (parent.config != null) {
+                    discordModule.getPlugin().getSLF4JLogger().error("DiscordCommandBridge: Mixing of subcommands and commands not allowed - {}", cmd);
+                    continue;
+                }
+                parent.addSubCommand(overrideSub, command);
+            }
+
+        }
+
+        discordModule.getDiscordBot().getJda().updateCommands()
+                .addCommands(commandMap.entrySet().stream().map(v -> v.getValue().getCommandData(v.getKey())).toList())
+                .queue(commands -> {
+                    if (commands != null) {
+                        for (Command command : commands) {
+                            DiscordCommand cmd = commandMap.get(command.getName());
+                            if (cmd != null) {
+                                this.commands.put(command.getId(), cmd);
+                            }
+                        }
+                    }
+                });
+    }
+
+    private DiscordCommand getCommand(String commandId, String subCommandName) {
+        DiscordCommand command = commands.get(commandId);
+        if (command != null && subCommandName != null && !subCommandName.isEmpty()) {
+            return command.getSubCommand(subCommandName);
+        }
+        return command;
+    }
+
+    @Override
+    public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
+        if (!event.isFromGuild() || event.getGuild() == null) {
+            event.reply("Commands are not allowed in DM").setEphemeral(true).queue(msg -> {
+                msg.deleteOriginal().queueAfter(10, TimeUnit.SECONDS);
+            });
+            return;
+        }
+        if (!event.getGuild().getId().equals(discordModule.getDiscordConfig().guildId.get())) {
+            event.reply("Commands are not allowed in this server").setEphemeral(true).queue(msg -> {
+                msg.deleteOriginal().queueAfter(10, TimeUnit.SECONDS);
+            });
+            return;
+        }
+        DiscordCommand command = getCommand(event.getCommandId(), event.getSubcommandName());
+        if (command == null) {
+            return;
+        }
+        event.deferReply(command.isEphemeral()).queue(hook -> {
+            PlayerIdentity player = accountLinkManager.getLinkedMinecraftAccount(event.getUser());
+            if (player == null) {
+                hook.editOriginal("You must link your account to use commands. Use this command in-game: /discord link")
+                        .queue(msg -> msg.delete().queueAfter(10, TimeUnit.SECONDS));
+                return;
+            }
+            DiscordCommandSender sender = new DiscordCommandSender(discordModule.getPlugin(), player, hook);
+            Bukkit.getScheduler().runTask(discordModule.getPlugin(), () -> command.execute(sender, event));
+        });
+    }
+
+    @Override
+    public void onCommandAutoCompleteInteraction(@NotNull CommandAutoCompleteInteractionEvent event) {
+        if (!event.isFromGuild() || event.getGuild() == null) {
+            event.replyChoices().queue();
+            return;
+        }
+        if (!event.getGuild().getId().equals(discordModule.getDiscordConfig().guildId.get())) {
+            event.replyChoices().queue();
+            return;
+        }
+        DiscordCommand command = getCommand(event.getCommandId(), event.getSubcommandName());
+        if (command == null) {
+            return;
+        }
+
+        PlayerIdentity player = accountLinkManager.getLinkedMinecraftAccount(event.getUser());
+        if (player == null) {
+            event.replyChoices().queue();
+            return;
+        }
+        DiscordCommandSender sender = new DiscordCommandSender(discordModule.getPlugin(), player);
+        Bukkit.getScheduler().runTask(discordModule.getPlugin(), () -> command.autocomplete(sender, event));
+    }
+
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/bot/command/DiscordCommandSender.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/bot/command/DiscordCommandSender.java
@@ -2,7 +2,7 @@ package com.froobworld.nabsuite.modules.discord.bot.command;
 
 import com.froobworld.nabsuite.NabSuite;
 import com.froobworld.nabsuite.data.identity.PlayerIdentity;
-import com.froobworld.nabsuite.user.OfflineCommandSender;
+import com.froobworld.nabsuite.command.sender.OfflineCommandSender;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.requests.RestAction;
@@ -14,13 +14,13 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 public class DiscordCommandSender extends OfflineCommandSender {
-
-    InteractionHook hook = null;
-    StringBuilder replyBuffer = null;
-    ScheduledFuture<?> future = null;
-    static final ANSIComponentSerializer ansi = ANSIComponentSerializer.builder().colorLevel(ColorLevel.INDEXED_8).build();
+    private static final ANSIComponentSerializer ansi = ANSIComponentSerializer.builder().colorLevel(ColorLevel.INDEXED_8).build();
+    private InteractionHook hook = null;
+    private StringBuilder replyBuffer = null;
+    private ScheduledFuture<?> future = null;
 
     public DiscordCommandSender(NabSuite plugin, PlayerIdentity player, InteractionHook event) {
         this(plugin, player);
@@ -52,13 +52,9 @@ public class DiscordCommandSender extends OfflineCommandSender {
         }
     }
 
-    public interface UpdateResponseHandler {
-        RestAction<Message> handle(InteractionHook hook);
-    }
-
-    public void updateResponse(@NotNull UpdateResponseHandler handler) {
+    public void updateResponse(@NotNull Function<InteractionHook, RestAction<Message>> handler) {
         if (hook != null && !hook.isExpired()) {
-            RestAction<Message> result = handler.handle(hook);
+            RestAction<Message> result = handler.apply(hook);
             if (result != null) {
                 result.queue();
                 hook = null;

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/bot/command/DiscordCommandSender.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/bot/command/DiscordCommandSender.java
@@ -1,0 +1,86 @@
+package com.froobworld.nabsuite.modules.discord.bot.command;
+
+import com.froobworld.nabsuite.NabSuite;
+import com.froobworld.nabsuite.data.identity.PlayerIdentity;
+import com.froobworld.nabsuite.user.OfflineCommandSender;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.ansi.ANSIComponentSerializer;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.ansi.ColorLevel;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public class DiscordCommandSender extends OfflineCommandSender {
+
+    InteractionHook hook = null;
+    StringBuilder replyBuffer = null;
+    ScheduledFuture<?> future = null;
+    static final ANSIComponentSerializer ansi = ANSIComponentSerializer.builder().colorLevel(ColorLevel.INDEXED_8).build();
+
+    public DiscordCommandSender(NabSuite plugin, PlayerIdentity player, InteractionHook event) {
+        this(plugin, player);
+        this.hook = event;
+        this.replyBuffer = new StringBuilder();
+        replyBuffer.append("```ansi\n");
+    }
+
+    public DiscordCommandSender(NabSuite plugin, PlayerIdentity player) {
+        super(plugin, player);
+    }
+
+    @Override
+    public void sendMessage(@NotNull String message) {
+        sendMessage(LegacyComponentSerializer.legacySection().deserialize(message));
+    }
+
+    @Override
+    public void sendRawMessage(@NotNull String s) {
+        sendMessage(Component.text(s));
+    }
+
+    @Override
+    public void sendMessage(@NotNull Component message) {
+        if (replyBuffer != null && hook != null) {
+            String out = ansi.serialize(message);
+            replyBuffer.append(out).append("\n");
+            queue();
+        }
+    }
+
+    public interface UpdateResponseHandler {
+        RestAction<Message> handle(InteractionHook hook);
+    }
+
+    public void updateResponse(@NotNull UpdateResponseHandler handler) {
+        if (hook != null && !hook.isExpired()) {
+            RestAction<Message> result = handler.handle(hook);
+            if (result != null) {
+                result.queue();
+                hook = null;
+            }
+        }
+    }
+
+    public void replyError(@NotNull String message) {
+        if (hook != null && !hook.isExpired()) {
+            hook.editOriginal(message).queue(msg -> msg.delete().queueAfter(10, TimeUnit.SECONDS));
+            hook = null;
+        }
+    }
+
+    public void queue() {
+        if (replyBuffer != null && hook != null && !hook.isExpired()) {
+            if (future != null && !future.isDone()) {
+                future.cancel(true);
+            }
+            // Give commands 20ms to send additional messages before updating response
+            future = hook.editOriginal(replyBuffer + "```").queueAfter(20, TimeUnit.MILLISECONDS);
+        }
+    }
+
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/bot/linking/AccountLinkBridge.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/bot/linking/AccountLinkBridge.java
@@ -2,7 +2,8 @@ package com.froobworld.nabsuite.modules.discord.bot.linking;
 
 import com.froobworld.nabsuite.data.identity.PlayerIdentity;
 import com.froobworld.nabsuite.modules.discord.DiscordModule;
-import net.dv8tion.jda.api.events.message.priv.PrivateMessageReceivedEvent;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,7 +18,10 @@ public class AccountLinkBridge extends ListenerAdapter {
     }
 
     @Override
-    public void onPrivateMessageReceived(@NotNull PrivateMessageReceivedEvent event) {
+    public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+        if (!event.isFromType(ChannelType.PRIVATE)) {
+            return;
+        }
         try {
             int code = Integer.parseInt(event.getMessage().getContentRaw());
             UUID uuid = accountLinkManager.getUuidForCode(code);

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/config/DiscordConfig.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/config/DiscordConfig.java
@@ -10,7 +10,7 @@ import java.io.File;
 import java.util.List;
 
 public class DiscordConfig extends NabConfiguration {
-    private static final int CONFIG_VERSION = 1;
+    private static final int CONFIG_VERSION = 2;
 
     public DiscordConfig(DiscordModule discordModule) {
         super(
@@ -29,6 +29,9 @@ public class DiscordConfig extends NabConfiguration {
 
     @Entry(key = "invite-url")
     public final ConfigEntry<String> inviteUrl = new ConfigEntry<>();
+
+    @Entry(key = "use-webhook")
+    public final ConfigEntry<Boolean> useWebhook = new ConfigEntry<>();
 
     @Section(key = "channels")
     public final Channels channels = new Channels();

--- a/src/main/java/com/froobworld/nabsuite/modules/discord/config/DiscordConfig.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/discord/config/DiscordConfig.java
@@ -1,11 +1,9 @@
 package com.froobworld.nabsuite.modules.discord.config;
 
-import com.froobworld.nabconfiguration.ConfigEntries;
-import com.froobworld.nabconfiguration.ConfigEntry;
-import com.froobworld.nabconfiguration.ConfigSection;
-import com.froobworld.nabconfiguration.NabConfiguration;
+import com.froobworld.nabconfiguration.*;
 import com.froobworld.nabconfiguration.annotations.Entry;
 import com.froobworld.nabconfiguration.annotations.Section;
+import com.froobworld.nabconfiguration.annotations.SectionMap;
 import com.froobworld.nabsuite.modules.discord.DiscordModule;
 
 import java.io.File;
@@ -68,6 +66,29 @@ public class DiscordConfig extends NabConfiguration {
 
         @Entry(key = "sync-roles")
         public final ConfigEntry<List<String>> syncRoles = ConfigEntries.stringListEntry();
+
+    }
+
+    @Section(key = "commands")
+    public final Commands commands = new Commands();
+
+    public static class Commands extends ConfigSection {
+
+        @Entry(key = "enabled")
+        public final ConfigEntry<List<String>> enabled = ConfigEntries.stringListEntry();
+
+        @SectionMap(key = "settings", defaultKey = "default")
+        public final ConfigSectionMap<String, CommandSettings> settings = new ConfigSectionMap<>(String::new, CommandSettings.class, true);
+
+    }
+
+    public static class CommandSettings extends ConfigSection {
+
+        @Entry(key = "override-name")
+        public final ConfigEntry<String> overrideName = new ConfigEntry<>();
+
+        @Entry(key = "public-reply")
+        public final ConfigEntry<Boolean> publicReply = new ConfigEntry<>();
 
     }
 

--- a/src/main/java/com/froobworld/nabsuite/user/OfflineCommandSender.java
+++ b/src/main/java/com/froobworld/nabsuite/user/OfflineCommandSender.java
@@ -1,0 +1,420 @@
+package com.froobworld.nabsuite.user;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.froobworld.nabsuite.NabSuite;
+import com.froobworld.nabsuite.data.identity.PlayerIdentity;
+import io.papermc.paper.persistence.PersistentDataContainerView;
+import net.kyori.adventure.text.Component;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.cacheddata.CachedPermissionData;
+import net.luckperms.api.model.user.User;
+import net.md_5.bungee.api.chat.BaseComponent;
+import org.bukkit.*;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.conversations.Conversation;
+import org.bukkit.conversations.ConversationAbandonedEvent;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionAttachment;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * Abstract CommandSender representing a player that may not be online.
+ * Should not be initialized on main thread since a blocking LuckPerms database lookup may be required
+ */
+abstract public class OfflineCommandSender extends CommandSender.Spigot implements ConsoleCommandSender, OfflinePlayer {
+
+    final PlayerIdentity player;
+    final OfflinePlayer offlinePlayer;
+    final CachedPermissionData permissionData;
+
+    public OfflineCommandSender(NabSuite plugin, PlayerIdentity player) {
+        if (Bukkit.isPrimaryThread()) {
+            throw new RuntimeException("OfflineCommandSender may perform blocking operations and should not be initialized on main thread");
+        }
+        this.player = player;
+        this.offlinePlayer = player.asOfflinePlayer();
+        LuckPerms luckPerms = plugin.getHookManager().getLuckPermsHook().getLuckPerms();
+        if (luckPerms != null) {
+            User user = luckPerms.getUserManager().getUser(player.getUuid());
+            if (user == null) {
+                user = luckPerms.getUserManager().loadUser(player.getUuid()).join();
+            }
+            if (user != null) {
+                this.permissionData = user.getCachedData().getPermissionData();
+            } else {
+                this.permissionData = null;
+            }
+        } else {
+            this.permissionData = null;
+        }
+    }
+
+    @Override
+    abstract public void sendMessage(@NotNull String message);
+
+    @Override
+    public void sendMessage(@NotNull String... strings) {
+        sendMessage(String.join("", strings));
+    }
+
+    @Override
+    public void sendMessage(@Nullable UUID uuid, @NotNull String s) {
+        sendMessage(s);
+    }
+
+    @Override
+    public void sendMessage(@Nullable UUID uuid, @NotNull String... strings) {
+        sendMessage(strings);
+    }
+
+    @Override
+    abstract public void sendRawMessage(@NotNull String s);
+
+    @Override
+    public void sendRawMessage(@Nullable UUID uuid, @NotNull String s) {
+        sendRawMessage(s);
+    }
+
+    @Override
+    public void sendMessage(@NotNull BaseComponent component) {
+        sendMessage(component.toLegacyText());
+    }
+
+    @Override
+    public void sendMessage(@NotNull BaseComponent... components) {
+        sendMessage(BaseComponent.toLegacyText(components));
+    }
+
+    @Override
+    public void sendMessage(@Nullable UUID sender, @NotNull BaseComponent component) {
+        sendMessage(component);
+    }
+
+    @Override
+    public void sendMessage(@Nullable UUID sender, @NotNull BaseComponent... components) {
+        sendMessage(components);
+    }
+
+    @Override
+    public @NotNull Server getServer() {
+        return Bukkit.getServer();
+    }
+
+    @Override
+    public boolean isOnline() {
+        return offlinePlayer.isOnline();
+    }
+
+    @Override
+    public boolean isConnected() {
+        return offlinePlayer.isConnected();
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return player.getLastName();
+    }
+
+    @Override
+    public @NotNull UUID getUniqueId() {
+        return player.getUuid();
+    }
+
+    @Override
+    public @NotNull PlayerProfile getPlayerProfile() {
+        return offlinePlayer.getPlayerProfile();
+    }
+
+    @Override
+    public boolean isBanned() {
+        return offlinePlayer.isBanned();
+    }
+
+    @Override
+    public <E extends BanEntry<? super PlayerProfile>> @Nullable E ban(@Nullable String s, @Nullable Date date, @Nullable String s1) {
+        return offlinePlayer.ban(s, date, s1);
+    }
+
+    @Override
+    public <E extends BanEntry<? super PlayerProfile>> @Nullable E ban(@Nullable String s, @Nullable Instant instant, @Nullable String s1) {
+        return offlinePlayer.ban(s, instant, s1);
+    }
+
+    @Override
+    public <E extends BanEntry<? super PlayerProfile>> @Nullable E ban(@Nullable String s, @Nullable Duration duration, @Nullable String s1) {
+        return offlinePlayer.ban(s, duration, s1);
+    }
+
+    @Override
+    public boolean isWhitelisted() {
+        return offlinePlayer.isWhitelisted();
+    }
+
+    @Override
+    public void setWhitelisted(boolean b) {
+        offlinePlayer.setWhitelisted(b);
+    }
+
+    @Override
+    public @Nullable Player getPlayer() {
+        return offlinePlayer.getPlayer();
+    }
+
+    @Override
+    public long getFirstPlayed() {
+        return offlinePlayer.getFirstPlayed();
+    }
+
+    @Override
+    public long getLastPlayed() {
+        return offlinePlayer.getLastPlayed();
+    }
+
+    @Override
+    public boolean hasPlayedBefore() {
+        return offlinePlayer.hasPlayedBefore();
+    }
+
+    @Override
+    public @Nullable Location getBedSpawnLocation() {
+        return offlinePlayer.getBedSpawnLocation();
+    }
+
+    @Override
+    public long getLastLogin() {
+        return offlinePlayer.getLastLogin();
+    }
+
+    @Override
+    public long getLastSeen() {
+        return offlinePlayer.getLastSeen();
+    }
+
+    @Override
+    public @Nullable Location getRespawnLocation() {
+        return offlinePlayer.getRespawnLocation();
+    }
+
+    @Override
+    public void incrementStatistic(@NotNull Statistic statistic) throws IllegalArgumentException {
+        offlinePlayer.incrementStatistic(statistic);
+    }
+
+    @Override
+    public void decrementStatistic(@NotNull Statistic statistic) throws IllegalArgumentException {
+        offlinePlayer.decrementStatistic(statistic);
+    }
+
+    @Override
+    public void incrementStatistic(@NotNull Statistic statistic, int i) throws IllegalArgumentException {
+        offlinePlayer.incrementStatistic(statistic, i);
+    }
+
+    @Override
+    public void decrementStatistic(@NotNull Statistic statistic, int i) throws IllegalArgumentException {
+        offlinePlayer.decrementStatistic(statistic, i);
+    }
+
+    @Override
+    public void setStatistic(@NotNull Statistic statistic, int i) throws IllegalArgumentException {
+        offlinePlayer.setStatistic(statistic, i);
+    }
+
+    @Override
+    public int getStatistic(@NotNull Statistic statistic) throws IllegalArgumentException {
+        return offlinePlayer.getStatistic(statistic);
+    }
+
+    @Override
+    public void incrementStatistic(@NotNull Statistic statistic, @NotNull Material material) throws IllegalArgumentException {
+        offlinePlayer.incrementStatistic(statistic, material);
+    }
+
+    @Override
+    public void decrementStatistic(@NotNull Statistic statistic, @NotNull Material material) throws IllegalArgumentException {
+        offlinePlayer.decrementStatistic(statistic, material);
+    }
+
+    @Override
+    public int getStatistic(@NotNull Statistic statistic, @NotNull Material material) throws IllegalArgumentException {
+        return offlinePlayer.getStatistic(statistic, material);
+    }
+
+    @Override
+    public void incrementStatistic(@NotNull Statistic statistic, @NotNull Material material, int i) throws IllegalArgumentException {
+        offlinePlayer.incrementStatistic(statistic, material, i);
+    }
+
+    @Override
+    public void decrementStatistic(@NotNull Statistic statistic, @NotNull Material material, int i) throws IllegalArgumentException {
+        offlinePlayer.decrementStatistic(statistic, material, i);
+    }
+
+    @Override
+    public void setStatistic(@NotNull Statistic statistic, @NotNull Material material, int i) throws IllegalArgumentException {
+        offlinePlayer.setStatistic(statistic, material, i);
+    }
+
+    @Override
+    public void incrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType) throws IllegalArgumentException {
+        offlinePlayer.incrementStatistic(statistic, entityType);
+    }
+
+    @Override
+    public void decrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType) throws IllegalArgumentException {
+        offlinePlayer.decrementStatistic(statistic, entityType);
+    }
+
+    @Override
+    public int getStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType) throws IllegalArgumentException {
+        return offlinePlayer.getStatistic(statistic, entityType);
+    }
+
+    @Override
+    public void incrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType, int i) throws IllegalArgumentException {
+        offlinePlayer.incrementStatistic(statistic, entityType, i);
+    }
+
+    @Override
+    public void decrementStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType, int i) {
+        offlinePlayer.decrementStatistic(statistic, entityType, i);
+    }
+
+    @Override
+    public void setStatistic(@NotNull Statistic statistic, @NotNull EntityType entityType, int i) {
+        offlinePlayer.setStatistic(statistic, entityType, i);
+    }
+
+    @Override
+    public @Nullable Location getLastDeathLocation() {
+        return offlinePlayer.getLastDeathLocation();
+    }
+
+    @Override
+    public @Nullable Location getLocation() {
+        return offlinePlayer.getLocation();
+    }
+
+    @Override
+    public PersistentDataContainerView getPersistentDataContainer() {
+        return offlinePlayer.getPersistentDataContainer();
+    }
+
+    @Override
+    public @NotNull Spigot spigot() {
+        return this;
+    }
+
+    @Override
+    public @NotNull Component name() {
+        return Component.text(player.getLastName());
+    }
+
+    @Override
+    public boolean isPermissionSet(@NotNull String s) {
+        return permissionData != null && permissionData.queryPermission(s).node() != null;
+    }
+
+    @Override
+    public boolean isPermissionSet(@NotNull Permission permission) {
+        return isPermissionSet(permission.getName());
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull String s) {
+        return permissionData != null && permissionData.checkPermission(s).asBoolean();
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull Permission permission) {
+        return hasPermission(permission.getName());
+    }
+
+    @Override
+    public @NotNull PermissionAttachment addAttachment(@NotNull Plugin plugin, @NotNull String s, boolean b) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NotNull PermissionAttachment addAttachment(@NotNull Plugin plugin) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @Nullable PermissionAttachment addAttachment(@NotNull Plugin plugin, @NotNull String s, boolean b, int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @Nullable PermissionAttachment addAttachment(@NotNull Plugin plugin, int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeAttachment(@NotNull PermissionAttachment permissionAttachment) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void recalculatePermissions() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NotNull Set<PermissionAttachmentInfo> getEffectivePermissions() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isOp() {
+        return offlinePlayer.isOp();
+    }
+
+    @Override
+    public void setOp(boolean b) {
+        offlinePlayer.setOp(b);
+    }
+
+    @Override
+    public @NotNull Map<String, Object> serialize() {
+        return offlinePlayer.serialize();
+    }
+
+
+    @Override
+    public boolean isConversing() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void acceptConversationInput(@NotNull String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean beginConversation(@NotNull Conversation conversation) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void abandonConversation(@NotNull Conversation conversation) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void abandonConversation(@NotNull Conversation conversation, @NotNull ConversationAbandonedEvent conversationAbandonedEvent) {
+        throw new UnsupportedOperationException();
+    }
+
+
+}

--- a/src/main/java/com/froobworld/nabsuite/util/ConsoleUtils.java
+++ b/src/main/java/com/froobworld/nabsuite/util/ConsoleUtils.java
@@ -1,7 +1,7 @@
 package com.froobworld.nabsuite.util;
 
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Entity;
 
 import java.util.UUID;
 
@@ -11,7 +11,7 @@ public final class ConsoleUtils {
     private ConsoleUtils() {}
 
     public static UUID getSenderUUID(CommandSender sender) {
-        return sender instanceof Entity ? ((Entity) sender).getUniqueId() : CONSOLE_UUID;
+        return sender instanceof OfflinePlayer ? ((OfflinePlayer) sender).getUniqueId() : CONSOLE_UUID;
     }
 
 }

--- a/src/main/resources/resources/discord/config-patches/1.patch
+++ b/src/main/resources/resources/discord/config-patches/1.patch
@@ -2,3 +2,58 @@
 key=use-webhook
 value=true
 comment=# Use webhook instead of websocket to send chat messages. Allows playername and skin to be shown instead of bot username and avatar
+
+[add-section]
+key=commands
+comment=# Discord Commands
+
+[add-field]
+key=commands.enabled
+value=\n    - "seen"\n    - "firstjoin"\n    - "playerlist"\n    - "ban"\n    - "unban"\n    - "restrict"\n    - "unrestrict"\n    - "confine"\n    - "unconfine"\n    - "jail"\n    - "unjail"\n    - "mute"\n    - "unmute"\n    - "antixray enable"\n    - "antixray disable"\n    - "antixray check"\n    - "punishmenthistory"\n    - "stafftasks"\n    - "ticket read"\n    - "ticket addnote"\n    - "ticket close"\n    - "notes add"\n    - "notes read"\n    - "warn"\n    - "tps"
+comment=# List of commands to expose in Discord
+
+[add-section]
+key=commands.settings
+
+[add-section]
+key=commands.settings.default
+
+[add-field]
+key=commands.settings.default.public-reply
+value=false
+comment=# Show command execution & reply to everyone in channel
+
+[add-field]
+key=commands.settings.default.override-name
+value=""
+comment=# Command name to use in discord, leave empty for same as in-game
+
+[add-section]
+key=commands.settings.ban
+
+[add-field]
+key=commands.settings.ban.override-name
+value=permban
+comment=# /ban conflicts with discord command
+
+[add-section]
+key=commands.settings.seen
+
+[add-field]
+key=commands.settings.seen.public-reply
+value=true
+
+[add-section]
+key=commands.settings.firstjoin
+
+[add-field]
+key=commands.settings.firstjoin.public-reply
+value=true
+
+[add-section]
+key=commands.settings.playerlist
+
+[add-field]
+key=commands.settings.playerlist.public-reply
+value=true
+

--- a/src/main/resources/resources/discord/config-patches/1.patch
+++ b/src/main/resources/resources/discord/config-patches/1.patch
@@ -1,0 +1,4 @@
+[add-field]
+key=use-webhook
+value=true
+comment=# Use webhook instead of websocket to send chat messages. Allows playername and skin to be shown instead of bot username and avatar

--- a/src/main/resources/resources/discord/config.yml
+++ b/src/main/resources/resources/discord/config.yml
@@ -1,5 +1,5 @@
 # Don't edit this.
-version: 1
+version: 2
 
 # The bot's token.
 bot-token: ""
@@ -36,3 +36,57 @@ roles:
   sync-roles:
     - "<mc group name1>:<discord role id1>"
     - "<mc group name2>:<discord role id2>"
+
+# Use webhook instead of websocket to send chat messages. Allows playername and skin to be shown instead of bot username and avatar
+use-webhook: true
+
+# Discord Commands
+commands:
+  # List of commands to expose in Discord
+  enabled:
+    - "seen"
+    - "firstjoin"
+    - "playerlist"
+    - "ban"
+    - "unban"
+    - "restrict"
+    - "unrestrict"
+    - "confine"
+    - "unconfine"
+    - "jail"
+    - "unjail"
+    - "mute"
+    - "unmute"
+    - "antixray enable"
+    - "antixray disable"
+    - "antixray check"
+    - "punishmenthistory"
+    - "stafftasks"
+    - "ticket read"
+    - "ticket addnote"
+    - "ticket close"
+    - "notes add"
+    - "notes read"
+    - "warn"
+    - "tps"
+
+  settings:
+    default:
+      # Show command execution & reply to everyone in channel
+      public-reply: false
+
+      # Command name to use in discord, leave empty for same as in-game
+      override-name: ""
+
+    ban:
+      # /ban conflicts with discord command
+      override-name: permban
+
+    seen:
+      public-reply: true
+
+    firstjoin:
+      public-reply: true
+
+    playerlist:
+      public-reply: true


### PR DESCRIPTION
Adds a configuration option to create discord commands corresponding to in-game commands.

Discord user must be linked to a minecraft account to use commands, all commands are then attributed to the player and permissions of the player are checked.

Commands are by default disabled for all roles and have to be enabled in discord server settings (can also be enabled only in specific channels)

Tab completion is available for all commands, argument description is available for NabCommands:
![image](https://github.com/user-attachments/assets/a9052ab4-03b8-43b2-ae4d-7164a2fb5d9b)


Also added `use-webhook` config option for the chat bridge, using the webhook will show the player username and avatar instead of the bot:s user and avatar:

![image](https://github.com/user-attachments/assets/6f11370f-6674-4e6e-8dd9-5863e9f52f56)

(set to false to restore previous behavior)

Command replies have some formatted output support (using discord ansi code-blocks):

![image](https://github.com/user-attachments/assets/04f6a38a-602c-462c-a26f-69c677cfe9e1)


Closes #16 

