### PR TITLE
Add nabsbegone command

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/nabmode/NabModeModule.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/nabmode/NabModeModule.java
@@ -3,6 +3,7 @@ package com.froobworld.nabsuite.modules.nabmode;
 import com.froobworld.nabsuite.NabModule;
 import com.froobworld.nabsuite.NabSuite;
 import com.froobworld.nabsuite.modules.nabmode.command.NabModeCommand;
+import com.froobworld.nabsuite.modules.nabmode.command.NabsBeGoneCommand;
 import com.froobworld.nabsuite.modules.nabmode.nabdimension.NabModeManager;
 import com.google.common.collect.Lists;
 
@@ -21,7 +22,8 @@ public class NabModeModule extends NabModule {
     @Override
     public void onEnable() {
         Lists.newArrayList(
-                new NabModeCommand(this)
+                new NabModeCommand(this),
+                new NabsBeGoneCommand(this)
         ).forEach(getPlugin().getCommandManager()::registerCommand);
     }
 

--- a/src/main/java/com/froobworld/nabsuite/modules/nabmode/command/NabsBeGoneCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/nabmode/command/NabsBeGoneCommand.java
@@ -1,0 +1,116 @@
+package com.froobworld.nabsuite.modules.nabmode.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.context.CommandContext;
+import com.froobworld.nabsuite.command.NabCommand;
+import com.froobworld.nabsuite.command.argument.arguments.PlayerArgument;
+import com.froobworld.nabsuite.command.argument.predicate.ArgumentPredicate;
+import com.froobworld.nabsuite.modules.basics.BasicsModule;
+import com.froobworld.nabsuite.modules.nabmode.NabModeModule;
+import com.froobworld.nabsuite.modules.nabmode.nabdimension.NabDimensionManager;
+import com.froobworld.nabsuite.util.NumberDisplayer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+public class NabsBeGoneCommand extends NabCommand {
+
+    private final NabModeModule nabModeModule;
+    private final BasicsModule basicsModule;
+    private final NabDimensionManager nabDimensionManager;
+
+    public NabsBeGoneCommand(NabModeModule nabModeModule) {
+        super(
+                "nabsbegone",
+                "Remove player(s) from nabworld.",
+                "nabsuite.command.nabsbegone",
+                CommandSender.class
+        );
+        this.nabModeModule = nabModeModule;
+        this.basicsModule = nabModeModule.getPlugin().getModule(BasicsModule.class);
+        this.nabDimensionManager = nabModeModule.getNabModeManager().getNabDimensionManager();
+    }
+
+    private void sendAway(Player player) {
+        Location backLocation = basicsModule.getBackManager().getBackLocation(player);
+        if (backLocation == null || nabDimensionManager.getNabWorld().equals(backLocation.getWorld())) {
+            backLocation = basicsModule.getSpawnManager().getSpawnLocation();
+        }
+        basicsModule.getPlayerTeleporter().teleportAsync(player, backLocation).thenAccept(location -> {
+            Location newBackLocation = basicsModule.getBackManager().getBackLocation(player);
+            if (newBackLocation != null && nabDimensionManager.getNabWorld().equals(newBackLocation.getWorld())) {
+                basicsModule.getBackManager().setBackLocation(player, null);
+            }
+            player.sendMessage(
+                    Component.text("Teleported to your previous location.").color(NamedTextColor.YELLOW)
+            );
+        });
+    }
+
+    @Override
+    public void execute(CommandContext<CommandSender> context) {
+        List<Component> nabNames = new LinkedList<>();
+
+        Optional<Player> playerArgument = context.getOptional("player");
+        if (playerArgument.isPresent()) {
+            Player player = playerArgument.get();
+            sendAway(player);
+            nabNames.add(player.displayName());
+        } else {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                if (!nabDimensionManager.getNabWorld().equals(player.getWorld())) {
+                    continue;
+                }
+                if (player.equals(context.getSender()) || nabModeModule.getNabModeManager().isNabMode(player)) {
+                    continue;
+                }
+                sendAway(player);
+                nabNames.add(player.displayName());
+            }
+        }
+
+        if (nabNames.isEmpty()) {
+            context.getSender().sendMessage(Component.text("The nabs are already gone.").color(NamedTextColor.YELLOW));
+        } else {
+            context.getSender().sendMessage(
+                    Component.text(NumberDisplayer.toStringWithModifier(nabNames.size(), " nab has", " nabs have", true) + " been removed: ").color(NamedTextColor.YELLOW)
+                            .append(Component.join(
+                                    JoinConfiguration.separator(Component.text(", ").color(NamedTextColor.YELLOW)),
+                                    nabNames
+                            ))
+                            .append(Component.text("."))
+            );
+        }
+
+    }
+
+    @Override
+    public Command.Builder<CommandSender> populateBuilder(Command.Builder<CommandSender> builder) {
+        return builder
+                .argument(new PlayerArgument<>(
+                        false,
+                        "player",
+                        new ArgumentPredicate<>(
+                                true,
+                                (context, player) -> nabDimensionManager.getNabWorld().equals(player.getWorld()),
+                                "That player isn't in nabworld."
+                        )
+                ));
+    }
+
+    @Override
+    public String getUsage() {
+        return "/nabsbegone [player]";
+    }
+}
+
+
+

--- a/src/main/java/com/froobworld/nabsuite/modules/nabmode/command/NabsBeGoneCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/nabmode/command/NabsBeGoneCommand.java
@@ -16,6 +16,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -30,7 +32,7 @@ public class NabsBeGoneCommand extends NabCommand {
     public NabsBeGoneCommand(NabModeModule nabModeModule) {
         super(
                 "nabsbegone",
-                "Remove player(s) from nabworld.",
+                "Remove players from nabworld.",
                 "nabsuite.command.nabsbegone",
                 CommandSender.class
         );
@@ -42,6 +44,9 @@ public class NabsBeGoneCommand extends NabCommand {
     private void sendAway(Player player) {
         Location backLocation = basicsModule.getBackManager().getBackLocation(player);
         if (backLocation == null || nabDimensionManager.getNabWorld().equals(backLocation.getWorld())) {
+            backLocation = player.getRespawnLocation();
+        }
+        if (backLocation == null) {
             backLocation = basicsModule.getSpawnManager().getSpawnLocation();
         }
         basicsModule.getPlayerTeleporter().teleportAsync(player, backLocation).thenAccept(location -> {
@@ -49,8 +54,9 @@ public class NabsBeGoneCommand extends NabCommand {
             if (newBackLocation != null && nabDimensionManager.getNabWorld().equals(newBackLocation.getWorld())) {
                 basicsModule.getBackManager().setBackLocation(player, null);
             }
+            player.addPotionEffect(new PotionEffect(PotionEffectType.DARKNESS, 4 * 20, 0));
             player.sendMessage(
-                    Component.text("Teleported to your previous location.").color(NamedTextColor.YELLOW)
+                    Component.text("You wake up... It was all just a dream. There is no nabworld.").color(NamedTextColor.YELLOW)
             );
         });
     }
@@ -81,12 +87,11 @@ public class NabsBeGoneCommand extends NabCommand {
             context.getSender().sendMessage(Component.text("The nabs are already gone.").color(NamedTextColor.YELLOW));
         } else {
             context.getSender().sendMessage(
-                    Component.text(NumberDisplayer.toStringWithModifier(nabNames.size(), " nab has", " nabs have", true) + " been removed: ").color(NamedTextColor.YELLOW)
+                    Component.text("Banished " + NumberDisplayer.toStringWithModifier(nabNames.size(), " nab", " nabs", false) + ": ").color(NamedTextColor.YELLOW)
                             .append(Component.join(
-                                    JoinConfiguration.separator(Component.text(", ").color(NamedTextColor.YELLOW)),
+                                    JoinConfiguration.separator(Component.text(", ").color(NamedTextColor.WHITE)),
                                     nabNames
                             ))
-                            .append(Component.text("."))
             );
         }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -297,6 +297,8 @@ permissions:
   #  description: "Access to the /togglevd command."
   nabsuite.command.nabmode:
     description: "Access to the /nabmode command."
+  nabsuite.command.nabsbegone:
+    description: "Access to the /nabsbegone command."
   nabsuite.command.effectivevd:
     description: "Access to the /effectivevd command."
   nabsuite.command.borderwarning:


### PR DESCRIPTION
Adds `/nabsbegone` command that removes players from nabworld.

No arguments removes all players except yourself and players in nabmode.
Optional argument player removes a single player

Currently the message "Teleported to your previous location." is sent to players that are removed, could be changed to something better.

The command can be exposed as a discord command