### PR TITLE
Add oreignore command

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/admin/AdminModule.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/admin/AdminModule.java
@@ -93,6 +93,7 @@ public class AdminModule extends NabModule {
                 //new GreylistCheckCommand(this),
                 //new GreylistRequestsCommand(this),
                 new OreStatsCommand(this),
+                new OreIgnoreCommand(this),
                 new StaffTasksCommand(this),
                 new PunishmentLogCommand(this),
                 new ModReqCommand(this),

--- a/src/main/java/com/froobworld/nabsuite/modules/admin/command/OreIgnoreAddCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/admin/command/OreIgnoreAddCommand.java
@@ -1,0 +1,56 @@
+package com.froobworld.nabsuite.modules.admin.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.context.CommandContext;
+import com.froobworld.nabsuite.command.NabCommand;
+import com.froobworld.nabsuite.command.argument.arguments.PlayerIdentityArgument;
+import com.froobworld.nabsuite.command.argument.predicate.ArgumentPredicate;
+import com.froobworld.nabsuite.data.identity.PlayerIdentity;
+import com.froobworld.nabsuite.modules.admin.AdminModule;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class OreIgnoreAddCommand extends NabCommand {
+
+    private final AdminModule adminModule;
+
+    public OreIgnoreAddCommand(AdminModule adminModule) {
+        super(
+                "add",
+                "Ignore ore alerts for player.",
+                "nabsuite.command.oreignore",
+                Player.class
+        );
+        this.adminModule = adminModule;
+    }
+
+    @Override
+    public void execute(CommandContext<CommandSender> context) {
+        Player sender = (Player) context.getSender();
+        PlayerIdentity target = context.get("player");
+        adminModule.getNotificationCentre().setIgnoreSource("ore-alert", sender, target.getUuid(), true);
+        sender.sendMessage(Component.text("Now ignoring ore alerts for " + target.getLastName()).color(NamedTextColor.YELLOW));
+    }
+
+    @Override
+    public Command.Builder<CommandSender> populateBuilder(Command.Builder<CommandSender> builder) {
+        return builder
+                .argument(new PlayerIdentityArgument<>(
+                        true,
+                        "player",
+                        adminModule.getPlugin().getPlayerIdentityManager(),
+                        true,
+                        new ArgumentPredicate<>(false, (context, playerIdentity) -> {
+                            Player sender = (Player) context.getSender();
+                            return !adminModule.getNotificationCentre().getIgnoredSources("ore-alert", sender).contains(playerIdentity.getUuid());
+                        }, "Player already ignored")
+                ));
+    }
+
+    @Override
+    public String getUsage() {
+        return "/oreignore add <player>";
+    }
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/admin/command/OreIgnoreCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/admin/command/OreIgnoreCommand.java
@@ -1,0 +1,49 @@
+package com.froobworld.nabsuite.modules.admin.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.context.CommandContext;
+import com.froobworld.nabsuite.command.NabCommand;
+import com.froobworld.nabsuite.command.NabParentCommand;
+import com.froobworld.nabsuite.command.argument.arguments.PlayerArgument;
+import com.froobworld.nabsuite.command.argument.arguments.PlayerIdentityArgument;
+import com.froobworld.nabsuite.command.argument.predicate.ArgumentPredicate;
+import com.froobworld.nabsuite.data.identity.PlayerIdentity;
+import com.froobworld.nabsuite.modules.admin.AdminModule;
+import com.froobworld.nabsuite.modules.admin.xray.PlayerOreStatsData;
+import com.froobworld.nabsuite.modules.basics.command.IgnoreAddCommand;
+import com.froobworld.nabsuite.modules.basics.command.IgnoreListCommand;
+import com.froobworld.nabsuite.modules.basics.command.IgnoreRemoveCommand;
+import com.froobworld.nabsuite.util.ComponentUtils;
+import com.froobworld.nabsuite.util.NumberDisplayer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+public class OreIgnoreCommand extends NabParentCommand {
+
+    public OreIgnoreCommand(AdminModule adminModule) {
+        super(
+                "oreignore",
+                "Ignores a player's ore alerts for this session.",
+                "nabsuite.command.oreignore",
+                Player.class
+        );
+        childCommands.addAll(List.of(
+                new OreIgnoreAddCommand(adminModule),
+                new OreIgnoreRemoveCommand(adminModule),
+                new OreIgnoreListCommand(adminModule)
+        ));
+    }
+
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/admin/command/OreIgnoreListCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/admin/command/OreIgnoreListCommand.java
@@ -1,0 +1,80 @@
+package com.froobworld.nabsuite.modules.admin.command;
+
+import cloud.commandframework.ArgumentDescription;
+import cloud.commandframework.Command;
+import cloud.commandframework.context.CommandContext;
+import com.froobworld.nabsuite.command.NabCommand;
+import com.froobworld.nabsuite.command.argument.arguments.PageNumberArgument;
+import com.froobworld.nabsuite.data.identity.PlayerIdentity;
+import com.froobworld.nabsuite.modules.admin.AdminModule;
+import com.froobworld.nabsuite.util.ListPaginator;
+import com.froobworld.nabsuite.util.NumberDisplayer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OreIgnoreListCommand extends NabCommand {
+    private static final int ITEMS_PER_PAGE = 20;
+    private final AdminModule adminModule;
+
+    public OreIgnoreListCommand(AdminModule adminModule) {
+        super(
+                "list",
+                "List players with ignored ore alerts.",
+                "nabsuite.command.oreignore",
+                Player.class
+        );
+        this.adminModule = adminModule;
+    }
+
+    @Override
+    public void execute(CommandContext<CommandSender> context) {
+        Player player = (Player) context.getSender();
+        List<Component> ignored = adminModule.getNotificationCentre().getIgnoredSources("ore-alert", player).stream()
+                .map(adminModule.getPlugin().getPlayerIdentityManager()::getPlayerIdentity)
+                .sorted((identity1, identity2) -> identity1.getLastName().compareToIgnoreCase(identity2.getLastName()))
+                .map(PlayerIdentity::displayName)
+                .collect(Collectors.toList());
+
+        if (ignored.isEmpty()) {
+            player.sendMessage(Component.text("You are not ignoring ore alerts from anyone.").color(NamedTextColor.YELLOW));
+        } else {
+            int pageNumber = context.get("page");
+            List<Component>[] pages = ListPaginator.paginate(ignored, ITEMS_PER_PAGE);
+            List<Component> page = pages[pageNumber - 1];
+            player.sendMessage(
+                    Component.text("You are ignoring ore alerts from " + NumberDisplayer.toStringWithModifier(ignored.size(), " player.", " players.", false))
+                            .append(Component.text(" Page " + pageNumber + "/" + pages.length + "."))
+                            .color(NamedTextColor.YELLOW)
+            );
+            player.sendMessage(Component.join(JoinConfiguration.separator(Component.text(", ")), page));
+        }
+    }
+
+    @Override
+    public Command.Builder<CommandSender> populateBuilder(Command.Builder<CommandSender> builder) {
+        return builder
+                .argument(
+                        new PageNumberArgument<>(
+                                false,
+                                "page",
+                                context -> {
+                                    Player player = (Player) context.getSender();
+                                    return adminModule.getNotificationCentre().getIgnoredSources("ore-alert", player).size();
+                                },
+                                ITEMS_PER_PAGE),
+                        ArgumentDescription.of("page")
+                );
+    }
+
+    @Override
+    public String getUsage() {
+        return "/oreignore list [page]";
+    }
+
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/admin/command/OreIgnoreRemoveCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/admin/command/OreIgnoreRemoveCommand.java
@@ -1,0 +1,56 @@
+package com.froobworld.nabsuite.modules.admin.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.context.CommandContext;
+import com.froobworld.nabsuite.command.NabCommand;
+import com.froobworld.nabsuite.command.argument.arguments.PlayerIdentityArgument;
+import com.froobworld.nabsuite.command.argument.predicate.ArgumentPredicate;
+import com.froobworld.nabsuite.data.identity.PlayerIdentity;
+import com.froobworld.nabsuite.modules.admin.AdminModule;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class OreIgnoreRemoveCommand extends NabCommand {
+
+    private final AdminModule adminModule;
+
+    public OreIgnoreRemoveCommand(AdminModule adminModule) {
+        super(
+                "remove",
+                "Stop ignoring ore alerts for player.",
+                "nabsuite.command.oreignore",
+                Player.class
+        );
+        this.adminModule = adminModule;
+    }
+
+    @Override
+    public void execute(CommandContext<CommandSender> context) {
+        Player sender = (Player) context.getSender();
+        PlayerIdentity target = context.get("player");
+        adminModule.getNotificationCentre().setIgnoreSource("ore-alert", sender, target.getUuid(), false);
+        sender.sendMessage(Component.text("No longer ignoring ore alerts for " + target.getLastName()).color(NamedTextColor.YELLOW));
+    }
+
+    @Override
+    public Command.Builder<CommandSender> populateBuilder(Command.Builder<CommandSender> builder) {
+        return builder
+                .argument(new PlayerIdentityArgument<>(
+                        true,
+                        "player",
+                        adminModule.getPlugin().getPlayerIdentityManager(),
+                        true,
+                        new ArgumentPredicate<>(false, (context, playerIdentity) -> {
+                            Player sender = (Player) context.getSender();
+                            return adminModule.getNotificationCentre().getIgnoredSources("ore-alert", sender).contains(playerIdentity.getUuid());
+                        }, "Player not ignored")
+                ));
+    }
+
+    @Override
+    public String getUsage() {
+        return "/oreignore remove <player>";
+    }
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/admin/notification/NotificationCentre.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/admin/notification/NotificationCentre.java
@@ -5,10 +5,15 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.WeakHashMap;
 
 public class NotificationCentre {
     private final Map<String, String> notificationPermissionMap = new HashMap<>();
+    private final Map<String, WeakHashMap<Player, Set<UUID>>> notificationIgnoreMap = new HashMap<>();
 
     public NotificationCentre() {
 
@@ -16,19 +21,53 @@ public class NotificationCentre {
 
     public void registerNotificationKey(String notificationKey, String permission) {
         notificationPermissionMap.put(notificationKey, permission);
+        notificationIgnoreMap.put(notificationKey, new WeakHashMap<>());
     }
 
     public void sendNotification(String notificationKey, Component notification) {
+        sendNotification(notificationKey, notification, null);
+    }
+
+    public void sendNotification(String notificationKey, Component notification, UUID source) {
         String permission = notificationPermissionMap.get(notificationKey);
-        if (permission == null) {
+        WeakHashMap<Player, Set<UUID>> ignoreMap = notificationIgnoreMap.get(notificationKey);
+        if (permission == null || ignoreMap == null) {
             throw new IllegalArgumentException("Unknown notification key '" + notificationKey + "'");
         }
         for (Player player : Bukkit.getOnlinePlayers()) {
             if (player.hasPermission(permission)) {
+                if ("ore-alert".equals(notificationKey) && player.getUniqueId().equals(source)) {
+                    // Don't send ore alerts to the player themselves, it would reveal how many ores they're expected to find
+                    continue;
+                }
+                if (source != null && ignoreMap.containsKey(player) && ignoreMap.get(player).contains(source)) {
+                    // Skip notifications for ignored sources
+                    continue;
+                }
                 player.sendMessage(notification);
             }
         }
         Bukkit.getConsoleSender().sendMessage(notification);
+    }
+
+    public void setIgnoreSource(String notificationKey, Player player, UUID source, boolean value) {
+        WeakHashMap<Player, Set<UUID>> ignoreMap = notificationIgnoreMap.get(notificationKey);
+        if (ignoreMap == null) {
+            throw new IllegalArgumentException("Unknown notification key '" + notificationKey + "'");
+        }
+        if (value) {
+            ignoreMap.computeIfAbsent(player, k -> new HashSet<>()).add(source);
+        } else {
+            ignoreMap.computeIfAbsent(player, k -> new HashSet<>()).remove(source);
+        }
+    }
+
+    public Set<UUID> getIgnoredSources(String notificationKey, Player player) {
+        WeakHashMap<Player, Set<UUID>> ignoreMap = notificationIgnoreMap.get(notificationKey);
+        if (ignoreMap == null) {
+            throw new IllegalArgumentException("Unknown notification key '" + notificationKey + "'");
+        }
+        return ignoreMap.computeIfAbsent(player, k -> new HashSet<>());
     }
 
 }

--- a/src/main/java/com/froobworld/nabsuite/modules/admin/xray/OreMonitor.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/admin/xray/OreMonitor.java
@@ -36,7 +36,7 @@ public class OreMonitor implements Listener {
                     .append(Component.text(" found " + NumberDisplayer.numberToString(veinSize, false) + " ", NamedTextColor.WHITE))
                     .append(oreName)
                     .append(Component.text(".", NamedTextColor.WHITE));
-            adminModule.getNotificationCentre().sendNotification("ore-alert", notification);
+            adminModule.getNotificationCentre().sendNotification("ore-alert", notification, miner.getUniqueId());
         }
     }
 

--- a/src/main/java/com/froobworld/nabsuite/modules/admin/xray/OreMonitor.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/admin/xray/OreMonitor.java
@@ -36,7 +36,10 @@ public class OreMonitor implements Listener {
                     .append(Component.text(" found " + NumberDisplayer.numberToString(veinSize, false) + " ", NamedTextColor.WHITE))
                     .append(oreName)
                     .append(Component.text(".", NamedTextColor.WHITE));
-            adminModule.getNotificationCentre().sendNotification("ore-alert", notification, miner.getUniqueId());
+            adminModule.getNotificationCentre().sendNotification("ore-alert", notification, miner.getUniqueId(),
+                    // Don't send ore alerts to the player themselves, as it would reveal how many ores they're expected to find
+                    target -> !miner.equals(target)
+            );
         }
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -197,6 +197,8 @@ permissions:
     description: "Access to the /mute command."
   nabsuite.command.orestats:
     description: "Access to the /orestats command."
+  nabsuite.command.oreignore:
+    description: "Access to the /oreignore command."
   nabsuite.command.punishmenthistory:
     description: "Access to the /punishmenthistory command."
   nabsuite.command.setjail:


### PR DESCRIPTION
Adds `/oreignore` with subcommands add/remove/list (similar to `/ignore`) for ignoring ore alerts from specific players.

During busy hours when multiple players are caving at the same time the ore alerts can get very spammy, adding a way to disable alerts for players that are confirmed to not x-ray would be useful.

Currently the ignore list is not persisted, but only valid per session (or until your `Player` is garbage collected).
I'm thinking that it's better to explicitly having to ignore players each time.

Another small change is that ore alerts will no longer be sent to the player triggering the alert, otherwise it helps the player out by telling them how many ores to expect and they would know if they miss hidden ores. In my opinion it would be better/more fair to not know.