### PR TITLE
Add /setgroup command and auto-demote

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/admin/notification/DiscordStaffLog.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/admin/notification/DiscordStaffLog.java
@@ -1,5 +1,6 @@
 package com.froobworld.nabsuite.modules.admin.notification;
 
+import com.froobworld.nabsuite.data.identity.PlayerIdentity;
 import com.froobworld.nabsuite.modules.admin.AdminModule;
 import com.froobworld.nabsuite.modules.admin.note.PlayerNote;
 import com.froobworld.nabsuite.modules.admin.punishment.PunishmentLogItem;
@@ -98,6 +99,26 @@ public class DiscordStaffLog {
                     .addField("Closed by", DiscordUtils.escapeMarkdown(resolverName), true)
                     .addField("Id", ticket.getId() + "", true)
                     .addField("Resolution", DiscordUtils.escapeMarkdown(closureMessage), true);
+
+            channel.sendMessageEmbeds(embedBuilder.build()).queue();
+        }
+    }
+
+    public void sendGroupChangeNotification(CommandSender sender, PlayerIdentity player, String newGroup) {
+        if (discordModule == null) {
+            return;
+        }
+
+        TextChannel channel = discordModule.getDiscordBot().getStaffLogChannel();
+        if (channel != null) {
+            String resolverName = sender instanceof OfflinePlayer ? sender.getName() : "Console";
+
+            EmbedBuilder embedBuilder = new EmbedBuilder().setTitle("Player group changed")
+                    .setColor(Color.GREEN)
+                    .setThumbnail(getSkinUrl(player.getUuid()))
+                    .addField("Changed by", DiscordUtils.escapeMarkdown(resolverName), true)
+                    .addField("Player", player.getLastName(), true)
+                    .addField("New Group", newGroup, true);
 
             channel.sendMessageEmbeds(embedBuilder.build()).queue();
         }

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/BasicsModule.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/BasicsModule.java
@@ -125,7 +125,8 @@ public class BasicsModule extends NabModule {
                 new LeaveChannelCommand(this),
                 new MessageChannelCommand(this),
                 new ReplyChannelCommand(this),
-                new ChannelsCommand(this)
+                new ChannelsCommand(this),
+                new SetGroupCommand(this)
         ).forEach(getPlugin().getCommandManager()::registerCommand);
     }
 
@@ -211,5 +212,9 @@ public class BasicsModule extends NabModule {
 
     public NameTagManager getNameTagManager() {
         return nameTagManager;
+    }
+
+    public GroupManager getGroupManager() {
+        return groupManager;
     }
 }

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/command/SetGroupCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/command/SetGroupCommand.java
@@ -1,0 +1,79 @@
+package com.froobworld.nabsuite.modules.basics.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.context.CommandContext;
+import com.froobworld.nabsuite.command.NabCommand;
+import com.froobworld.nabsuite.command.argument.arguments.PlayerIdentityArgument;
+import com.froobworld.nabsuite.command.argument.predicate.ArgumentPredicate;
+import com.froobworld.nabsuite.data.identity.PlayerIdentity;
+import com.froobworld.nabsuite.modules.admin.AdminModule;
+import com.froobworld.nabsuite.modules.basics.BasicsModule;
+import com.froobworld.nabsuite.modules.basics.command.argument.GroupArgument;
+import com.froobworld.nabsuite.modules.basics.permissions.GroupManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
+
+public class SetGroupCommand extends NabCommand {
+    private final BasicsModule basicsModule;
+
+    public SetGroupCommand(BasicsModule basicsModule) {
+        super(
+                "setgroup",
+                "Change the primary group for a player.",
+                "nabsuite.command.setgroup",
+                CommandSender.class
+        );
+        this.basicsModule = basicsModule;
+    }
+
+    @Override
+    public void execute(CommandContext<CommandSender> context) {
+        PlayerIdentity target = context.get("player");
+        String group = context.get("group");
+        basicsModule.getGroupManager().changePrimaryGroup(
+                target.getUuid(),
+                group,
+                user -> context.getSender().hasPermission(GroupManager.SETGROUP_PERMISSION_PREFIX + user.getPrimaryGroup().toLowerCase()),
+                user -> context.getSender() instanceof ConsoleCommandSender || !user.getCachedData().getPermissionData().checkPermission(GroupManager.SETGROUP_IMMUNE_PERMISSION).asBoolean()
+            ).handleAsync((v, e) -> {
+                    if (e != null && e.getCause() instanceof IllegalArgumentException) {
+                        context.getSender().sendMessage(Component.text(e.getCause().getMessage()).color(NamedTextColor.RED));
+                    } else if (e != null) {
+                        basicsModule.getPlugin().getSLF4JLogger().error("Error trying to set group of {} to {}", target.getLastName(), group, e.getCause());
+                        context.getSender().sendMessage(Component.text("Internal error").color(NamedTextColor.RED));
+                    } else {
+                        context.getSender().sendMessage(Component.text("Changed group for " + target.getLastName() + " to '" + group + "'").color(NamedTextColor.YELLOW));
+                        basicsModule.getPlugin().getModule(AdminModule.class).getDiscordStaffLog().sendGroupChangeNotification(context.getSender(), target, group);
+                    }
+                    return null;
+                }, Bukkit.getScheduler().getMainThreadExecutor(basicsModule.getPlugin()));
+    }
+
+    @Override
+    public Command.Builder<CommandSender> populateBuilder(Command.Builder<CommandSender> builder) {
+        return builder.argument(new PlayerIdentityArgument<>(
+                true,
+                "player",
+                basicsModule.getPlugin().getPlayerIdentityManager(),
+                true,
+                new ArgumentPredicate<>(
+                        true,
+                        (context, player) -> !(context.getSender() instanceof Player sender) || !sender.getUniqueId().equals(player.getUuid()),
+                        "You can't change your own group."
+                )
+        )).argument(new GroupArgument<>(
+                true,
+                "group",
+                basicsModule.getPlugin().getUserManager().getGroupUserManager(),
+                new ArgumentPredicate<>(
+                        true,
+                        (context, group) -> context.getSender().hasPermission(GroupManager.SETGROUP_PERMISSION_PREFIX + group.toLowerCase()),
+                        "You don't have permission for that group."
+                )
+        ));
+    }
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/command/argument/GroupArgument.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/command/argument/GroupArgument.java
@@ -1,0 +1,70 @@
+package com.froobworld.nabsuite.modules.basics.command.argument;
+
+import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
+import com.froobworld.nabsuite.command.argument.predicate.ArgumentPredicate;
+import com.froobworld.nabsuite.user.GroupUserManager;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class GroupArgument<C> extends CommandArgument<C, String> {
+
+    @SafeVarargs
+    public GroupArgument(boolean required, @NonNull String name, GroupUserManager groupUserManager, ArgumentPredicate<C, String>... predicates) {
+        super(required, name, new GroupArgument.Parser<>(groupUserManager, predicates), String.class);
+    }
+
+    private static final class Parser<C> implements ArgumentParser<C, String> {
+        private final GroupUserManager groupUserManager;
+        private final ArgumentPredicate<C, String>[] predicates;
+
+        @SafeVarargs
+        private Parser(GroupUserManager groupUserManager, ArgumentPredicate<C, String>... predicates) {
+            this.groupUserManager = groupUserManager;
+            this.predicates = predicates;
+        }
+
+        @Override
+        public @NonNull ArgumentParseResult<String> parse(@NonNull CommandContext<C> commandContext, @NonNull Queue<String> inputQueue) {
+            if (inputQueue.isEmpty()) {
+                return ArgumentParseResult.failure(new NoInputProvidedException(GroupArgument.Parser.class, commandContext));
+            }
+
+            String input = inputQueue.remove();
+            for (String group: groupUserManager.getAllowableGroups()) {
+                if (input.equalsIgnoreCase(group)) {
+                    return ArgumentPredicate.testAll(commandContext, group, predicates);
+                }
+            }
+
+            return ArgumentParseResult.failure(new GroupNotFoundException(input));
+        }
+
+        @Override
+        public @NonNull List<String> suggestions(@NonNull CommandContext<C> commandContext, @NonNull String input) {
+            return groupUserManager.getAllowableGroups().stream()
+                    .filter(group -> group.toLowerCase().startsWith(input.toLowerCase()))
+                    .filter(group -> ArgumentPredicate.testAll(commandContext, group, predicates).getFailure().isEmpty())
+                    .collect(Collectors.toList());
+        }
+
+        @Override
+        public boolean isContextFree() {
+            return ArgumentPredicate.allContextFree(predicates);
+        }
+
+    }
+
+    public static class GroupNotFoundException extends IllegalArgumentException {
+
+        public GroupNotFoundException(String input) {
+            super("No group found for input '" + input + "'");
+        }
+
+    }
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/config/BasicsConfig.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/config/BasicsConfig.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.function.Function;
 
 public class BasicsConfig extends NabConfiguration {
-    private static final int CONFIG_VERSION = 6;
+    private static final int CONFIG_VERSION = 7;
 
     public BasicsConfig(BasicsModule basicsModule) {
         super(
@@ -86,6 +86,22 @@ public class BasicsConfig extends NabConfiguration {
 
         @EntryMap(key = "required-time", defaultKey = "other")
         public final ConfigEntryMap<String, Integer> requiredTime = new ConfigEntryMap<>(Function.identity(), ConfigEntries::integerEntry, true);
+
+    }
+
+    @Section(key = "auto-demote")
+    public final AutoDemote autoDemote = new AutoDemote();
+
+    public static class AutoDemote extends ConfigSection {
+
+        @Entry(key = "groups")
+        public final ConfigEntry<List<String>> groups = ConfigEntries.stringListEntry();
+
+        @EntryMap(key = "inactive-time", defaultKey = "default")
+        public final ConfigEntryMap<String, Integer> inactiveTime = new ConfigEntryMap<>(Function.identity(), ConfigEntries::integerEntry, true);
+
+        @EntryMap(key = "demote-to-group", defaultKey = "default")
+        public final ConfigEntryMap<String, String> demoteToGroup = new ConfigEntryMap<>(Function.identity(), ConfigEntry::new, true);
 
     }
 

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/permissions/AutoGroupChecker.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/permissions/AutoGroupChecker.java
@@ -46,6 +46,7 @@ public class AutoGroupChecker {
             if (daysRequired > 0 && daysPlayed > daysRequired) {
                 track.promote(user, luckPerms.getContextManager().getStaticContext());
                 luckPerms.getUserManager().saveUser(user);
+                playerData.updateLastGroupChange();
             }
 
         });

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/permissions/AutoGroupDemoter.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/permissions/AutoGroupDemoter.java
@@ -1,0 +1,73 @@
+package com.froobworld.nabsuite.modules.basics.permissions;
+
+import com.froobworld.nabsuite.data.identity.PlayerIdentity;
+import com.froobworld.nabsuite.modules.admin.AdminModule;
+import com.froobworld.nabsuite.modules.basics.BasicsModule;
+import com.froobworld.nabsuite.modules.basics.player.PlayerData;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.model.user.UserManager;
+import net.luckperms.api.node.matcher.NodeMatcher;
+import net.luckperms.api.node.types.InheritanceNode;
+import org.bukkit.Bukkit;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+public class AutoGroupDemoter {
+    private final BasicsModule basicsModule;
+    private final LuckPerms luckPerms;
+
+    public AutoGroupDemoter(BasicsModule basicsModule, LuckPerms luckPerms) {
+        this.basicsModule = basicsModule;
+        this.luckPerms = luckPerms;
+
+        // Run 30s after start and then every 4h
+        Bukkit.getScheduler().runTaskTimerAsynchronously(basicsModule.getPlugin(), this::demotePlayersTask, 20*30, 20*60*60*4);
+    }
+
+    private void demotePlayersTask() {
+        try {
+            UserManager lpUserManager = luckPerms.getUserManager();
+            for (String groupName: basicsModule.getConfig().autoDemote.groups.get()) {
+                int inactiveDays = basicsModule.getConfig().autoDemote.inactiveTime.of(groupName).get();
+                String targetGroup = basicsModule.getConfig().autoDemote.demoteToGroup.of(groupName).get();
+                long cutoff = System.currentTimeMillis() - (long) inactiveDays * 24 * 60 * 60 * 1000;
+                NodeMatcher<InheritanceNode> matcher = NodeMatcher.key(InheritanceNode.builder(groupName).build());
+                for (UUID uuid : lpUserManager.searchAll(matcher).get().keySet()) {
+                    User user = lpUserManager.loadUser(uuid).get();
+                    if (user.getCachedData().getPermissionData().checkPermission(GroupManager.SETGROUP_IMMUNE_PERMISSION).asBoolean()) {
+                        continue;
+                    }
+                    if (groupName.equalsIgnoreCase(user.getPrimaryGroup())) {
+                        PlayerData playerData = basicsModule.getPlayerDataManager().getPlayerData(uuid);
+                        if (playerData != null && playerData.getLastPlayed() > 0 && playerData.getLastPlayed() < cutoff && playerData.getLastGroupChange() < cutoff) {
+                            basicsModule.getGroupManager().changePrimaryGroup(uuid, targetGroup).handleAsync((v, e) -> {
+                                PlayerIdentity playerIdentity = basicsModule.getPlugin().getPlayerIdentityManager().getPlayerIdentity(uuid);
+                                if (e != null) {
+                                    basicsModule.getPlugin().getSLF4JLogger().error(
+                                            "AutoGroupDemoter: Failed changing group of {} from {} to {}",
+                                            playerIdentity.getLastName(), groupName, targetGroup, e.getCause()
+                                    );
+                                } else {
+                                    basicsModule.getPlugin().getSLF4JLogger().info(
+                                            "AutoGroupDemoter: Changed group of {} from {} to {}",
+                                            playerIdentity.getLastName(), groupName, targetGroup
+                                    );
+                                    basicsModule.getPlugin().getModule(AdminModule.class).getTicketManager().createSystemTicket(basicsModule.getSpawnManager().getSpawnLocation(),
+                                            "Player " + playerIdentity.getLastName() + " has changed group from '" + groupName + "' to '" + targetGroup + "' due to inactivity. Please ensure their Discord roles are updated."
+                                    );
+                                }
+                                return null;
+                            }, Bukkit.getScheduler().getMainThreadExecutor(basicsModule.getPlugin()));
+                        }
+                    }
+
+                }
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            basicsModule.getPlugin().getSLF4JLogger().error("AutoGroupDemoter: Interrupted while waiting for luckperms", e);
+        }
+    }
+
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/permissions/GroupManager.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/permissions/GroupManager.java
@@ -1,7 +1,9 @@
 package com.froobworld.nabsuite.modules.basics.permissions;
 
+import com.froobworld.nabsuite.data.identity.PlayerIdentity;
 import com.froobworld.nabsuite.modules.admin.AdminModule;
 import com.froobworld.nabsuite.modules.basics.BasicsModule;
+import com.froobworld.nabsuite.modules.basics.player.PlayerData;
 import io.papermc.paper.chat.ChatRenderer;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.Component;
@@ -12,6 +14,9 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.event.user.UserDataRecalculateEvent;
 import net.luckperms.api.event.user.track.UserTrackEvent;
+import net.luckperms.api.model.group.Group;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.node.types.InheritanceNode;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -19,10 +24,17 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+
 public class GroupManager implements Listener {
     private final BasicsModule basicsModule;
     private final AdminModule adminModule;
     private final LuckPerms luckPerms;
+
+    public static final String SETGROUP_IMMUNE_PERMISSION = "nabsuite.setgroup.immune";
+    public static final String SETGROUP_PERMISSION_PREFIX = "nabsuite.setgroup.group.";
 
     public GroupManager(BasicsModule basicsModule) {
         this.basicsModule = basicsModule;
@@ -36,6 +48,7 @@ public class GroupManager implements Listener {
             luckPerms.getEventBus().subscribe(UserDataRecalculateEvent.class, this::onUserDataRecalculate);
             luckPerms.getEventBus().subscribe(UserTrackEvent.class, this::onTrackChangePosition);
             new AutoGroupChecker(basicsModule, luckPerms);
+            new AutoGroupDemoter(basicsModule, luckPerms);
         }
     }
 
@@ -94,5 +107,30 @@ public class GroupManager implements Listener {
         player.displayName(MiniMessage.miniMessage().deserialize(format, TagResolver.resolver("name", Tag.inserting(Component.text(player.getName())))));
     }
 
+    @SafeVarargs
+    public final CompletableFuture<Void> changePrimaryGroup(UUID uuid, String group, Predicate<User>... userPredicates) {
+        return luckPerms.getUserManager().loadUser(uuid).thenCompose(user -> {
+            PlayerIdentity playerIdentity = basicsModule.getPlugin().getPlayerIdentityManager().getPlayerIdentity(uuid);
+            String currentGroup = user.getPrimaryGroup();
+            if (group.equalsIgnoreCase(currentGroup)) {
+                throw new IllegalArgumentException("User " + playerIdentity.getLastName() + " is already a member of group '" + group + "'.");
+            }
+            for (Predicate<User> predicate : userPredicates) {
+                if (!predicate.test(user)) {
+                    throw new IllegalArgumentException("You don't have permission to change the group of " + playerIdentity.getLastName() + ".");
+                }
+            }
+            Group targetGroup = luckPerms.getGroupManager().getGroup(group);
+            if (targetGroup == null) {
+                throw new IllegalArgumentException("Group '" + group + "' doesn't exist.");
+            }
+            user.data().add(InheritanceNode.builder(targetGroup).build());
+            user.setPrimaryGroup(group);
+            user.data().remove(InheritanceNode.builder(currentGroup).build());
+            PlayerData playerData = basicsModule.getPlayerDataManager().getPlayerData(uuid);
+            playerData.updateLastGroupChange();
+            return luckPerms.getUserManager().saveUser(user);
+        });
+    }
 
 }

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/player/PlayerData.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/player/PlayerData.java
@@ -23,6 +23,10 @@ public class PlayerData {
                     playerData -> playerData.lastPlayed,
                     (playerData, lastPlayed) -> playerData.lastPlayed = lastPlayed
             ))
+            .addField("last-group-change", SchemaEntries.longEntry(
+                    playerData -> playerData.lastGroupChange,
+                    (playerData, lastGroupChange) -> playerData.lastGroupChange = lastGroupChange
+            ))
             .addField("friends", SchemaEntries.setEntry(
                     playerData -> playerData.friends,
                     (playerData, uuids) -> playerData.friends = uuids,
@@ -47,6 +51,7 @@ public class PlayerData {
     private final PlayerDataManager playerDataManager;
     private UUID uuid;
     private long lastPlayed;
+    private long lastGroupChange;
     private long firstJoined;
     private Set<UUID> ignored;
     private Set<UUID> friends;
@@ -78,6 +83,10 @@ public class PlayerData {
 
     public long getLastPlayed() {
         return lastPlayed;
+    }
+
+    public long getLastGroupChange() {
+        return lastGroupChange;
     }
 
     public Set<UUID> getIgnored() {
@@ -136,6 +145,11 @@ public class PlayerData {
 
     void updateLastPlayedTime() {
         lastPlayed = System.currentTimeMillis();
+        playerDataManager.playerDataSaver.scheduleSave(this);
+    }
+
+    public void updateLastGroupChange() {
+        lastGroupChange = System.currentTimeMillis();
         playerDataManager.playerDataSaver.scheduleSave(this);
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -55,6 +55,8 @@ permissions:
     description: "Access to the /rules command."
   nabsuite.command.seen:
     description: "Access to the /seen command."
+  nabsuite.command.setgroup:
+    description: "Access to the /setgroup command."
   nabsuite.command.sethome:
     description: "Access to the /sethome command."
   nabsuite.command.setwarp:
@@ -169,6 +171,10 @@ permissions:
     description: "Provides the ability to teleport to all players."
   nabsuite.changegroupalert:
     description: "Alerts when a user changes group."
+  nabsuite.setgroup.immune:
+    description: "Immune to group changes through /setgroup or auto-demote"
+  nabsuite.setgroup.group.*:
+    description: "Allow group to be used in /setgroup"
 
   # Admin module commands
   #nabsuite.command.accept:

--- a/src/main/resources/resources/basics/config-patches/6.patch
+++ b/src/main/resources/resources/basics/config-patches/6.patch
@@ -1,0 +1,32 @@
+[add-section]
+key=auto-demote
+comment=# Auto demote users due to inactivity
+
+[add-field]
+key=auto-demote.groups
+value=\n    - "trusted"\n    - "staff"
+comment=# Groups that should be checked for inactivity
+
+[add-section]
+key=auto-demote.inactive-time
+comment=# How long (in days) does the user need to be inactive to get demoted from this group?
+
+[add-field]
+key=auto-demote.inactive-time.default
+value=365
+
+[add-field]
+key=auto-demote.inactive-time.staff
+value=730
+
+[add-section]
+key=auto-demote.demote-to-group
+comment=# Which group the user should get demoted to
+
+[add-field]
+key=auto-demote.demote-to-group.default
+value=veteran
+
+[add-field]
+key=auto-demote.demote-to-group.staff
+value=trusted

--- a/src/main/resources/resources/basics/config.yml
+++ b/src/main/resources/resources/basics/config.yml
@@ -1,5 +1,5 @@
 # Don't edit this.
-version: 6
+version: 7
 
 # The highest number to check when testing a player's permissions for the maximum number of homes they can set.
 max-home-permission-check: 3
@@ -157,3 +157,21 @@ name-tag:
 
     suffix: " <yellow>(vanished)</yellow>"
 
+# Auto demote users due to inactivity
+auto-demote:
+  # Groups that should be checked for inactivity
+  groups:
+    - "trusted"
+    - "staff"
+
+  # How long (in days) does the user need to be inactive to get demoted from this group?
+  inactive-time:
+    default: 365
+
+    staff: 730
+
+  # Which group the user should get demoted to
+  demote-to-group:
+    default: veteran
+
+    staff: trusted


### PR DESCRIPTION
Adds command `/setgroup <player> <group>`.

Permissions are needed for both the current and target group, changing groups from veteran to trusted requires both permissions `nabsuite.setgroup.group.veteran` and `nabsuite.setgroup.group.trusted`.

To disallow all group changes for a player, they can be given permission `nabsuite.setgroup.immune`

A new `lastGroupChange` field has been added to PlayerData, this is to prevent multiple demotions to happen at once.
For example if staff is demoted to trusted after inactivity - the inactivity timer for demotion from trusted would start counting from the previous demotion instead of last activity.