### PR TITLE
Toggle automatic replanting of trees

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/mechs/MechsModule.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/mechs/MechsModule.java
@@ -8,6 +8,7 @@ import com.froobworld.nabsuite.modules.mechs.command.BorderWarningCommand;
 import com.froobworld.nabsuite.modules.mechs.command.EffectiveViewDistanceCommand;
 import com.froobworld.nabsuite.modules.mechs.command.PvpCommand;
 import com.froobworld.nabsuite.modules.mechs.command.ToggleViewDistanceCommand;
+import com.froobworld.nabsuite.modules.mechs.command.AutoReplantCommand;
 import com.froobworld.nabsuite.modules.mechs.config.MechsConfig;
 import com.froobworld.nabsuite.modules.mechs.signedit.SignEditDisabler;
 import com.froobworld.nabsuite.modules.mechs.mobgriefing.MobGriefingManager;
@@ -50,7 +51,8 @@ public class MechsModule extends NabModule {
                 new PvpCommand(this),
                 new ToggleViewDistanceCommand(this),
                 //new EffectiveViewDistanceCommand(),
-                new BorderWarningCommand(this)
+                new BorderWarningCommand(this),
+                new AutoReplantCommand(this)
         ).forEach(getPlugin().getCommandManager()::registerCommand);
     }
 
@@ -66,6 +68,10 @@ public class MechsModule extends NabModule {
 
     public PvpManager getPvpManager() {
         return pvpManager;
+    }
+
+    public TreeManager getTreeManager() {
+        return treeManager;
     }
 
     public ViewDistanceManager getViewDistanceManager() {

--- a/src/main/java/com/froobworld/nabsuite/modules/mechs/MechsModule.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/mechs/MechsModule.java
@@ -5,10 +5,9 @@ import com.froobworld.nabsuite.NabSuite;
 import com.froobworld.nabsuite.modules.mechs.border.WorldBorderManager;
 import com.froobworld.nabsuite.modules.mechs.chat.ClickableLinkReplacer;
 import com.froobworld.nabsuite.modules.mechs.command.BorderWarningCommand;
-import com.froobworld.nabsuite.modules.mechs.command.EffectiveViewDistanceCommand;
 import com.froobworld.nabsuite.modules.mechs.command.PvpCommand;
 import com.froobworld.nabsuite.modules.mechs.command.ToggleViewDistanceCommand;
-import com.froobworld.nabsuite.modules.mechs.command.AutoReplantCommand;
+import com.froobworld.nabsuite.modules.mechs.command.NoReplantCommand;
 import com.froobworld.nabsuite.modules.mechs.config.MechsConfig;
 import com.froobworld.nabsuite.modules.mechs.signedit.SignEditDisabler;
 import com.froobworld.nabsuite.modules.mechs.mobgriefing.MobGriefingManager;
@@ -52,7 +51,7 @@ public class MechsModule extends NabModule {
                 new ToggleViewDistanceCommand(this),
                 //new EffectiveViewDistanceCommand(),
                 new BorderWarningCommand(this),
-                new AutoReplantCommand(this)
+                new NoReplantCommand(this)
         ).forEach(getPlugin().getCommandManager()::registerCommand);
     }
 

--- a/src/main/java/com/froobworld/nabsuite/modules/mechs/command/AutoReplantCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/mechs/command/AutoReplantCommand.java
@@ -1,0 +1,42 @@
+package com.froobworld.nabsuite.modules.mechs.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.context.CommandContext;
+import com.froobworld.nabsuite.command.NabCommand;
+import com.froobworld.nabsuite.modules.mechs.MechsModule;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class AutoReplantCommand extends NabCommand {
+    private final MechsModule mechsModule;
+
+    public AutoReplantCommand(MechsModule mechsModule) {
+        super(
+                "autoreplant",
+                "Toggle automatic tree replanting.",
+                "nabsuite.command.autoreplant",
+                Player.class
+        );
+        this.mechsModule = mechsModule;
+    }
+
+    @Override
+    public void execute(CommandContext<CommandSender> context) {
+        Player sender = (Player) context.getSender();
+        boolean current = mechsModule.getTreeManager().replantEnabled(sender);
+
+        mechsModule.getTreeManager().setReplantEnabled(sender, !current);
+        if (current) {
+            sender.sendMessage(Component.text("Automatic tree replanting disabled.", NamedTextColor.YELLOW));
+        } else {
+            sender.sendMessage(Component.text("Automatic tree replanting enabled.", NamedTextColor.YELLOW));
+        }
+    }
+
+    @Override
+    public Command.Builder<CommandSender> populateBuilder(Command.Builder<CommandSender> builder) {
+        return builder;
+    }
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/mechs/command/NoReplantCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/mechs/command/NoReplantCommand.java
@@ -9,14 +9,14 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-public class AutoReplantCommand extends NabCommand {
+public class NoReplantCommand extends NabCommand {
     private final MechsModule mechsModule;
 
-    public AutoReplantCommand(MechsModule mechsModule) {
+    public NoReplantCommand(MechsModule mechsModule) {
         super(
-                "autoreplant",
+                "noreplant",
                 "Toggle automatic tree replanting.",
-                "nabsuite.command.autoreplant",
+                "nabsuite.command.noreplant",
                 Player.class
         );
         this.mechsModule = mechsModule;
@@ -29,7 +29,7 @@ public class AutoReplantCommand extends NabCommand {
 
         mechsModule.getTreeManager().setReplantEnabled(sender, !current);
         if (current) {
-            sender.sendMessage(Component.text("Automatic tree replanting disabled.", NamedTextColor.YELLOW));
+            sender.sendMessage(Component.text("Automatic tree replanting disabled temporarily.", NamedTextColor.YELLOW));
         } else {
             sender.sendMessage(Component.text("Automatic tree replanting enabled.", NamedTextColor.YELLOW));
         }

--- a/src/main/java/com/froobworld/nabsuite/modules/mechs/trees/TreeManager.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/mechs/trees/TreeManager.java
@@ -7,12 +7,15 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.io.File;
 import java.util.regex.Pattern;
@@ -22,8 +25,10 @@ public class TreeManager implements Listener {
     protected final DataSaver regionDataSaver;
     private final BiMap<UnnaturalLogRegion.Key, UnnaturalLogRegion> logRegionMap = HashBiMap.create();
     private final File directory;
+    private final NamespacedKey replantPdcKey;
 
     public TreeManager(MechsModule mechsModule) {
+        this.replantPdcKey = new NamespacedKey(mechsModule.getPlugin(), "tree-replanter-enabled");
         directory = new File(mechsModule.getDataFolder(), "unnatural-logs/");
         regionDataSaver = new DataSaver(mechsModule.getPlugin(), 1200 * 5);
         logRegionMap.putAll(DataLoader.loadAll(
@@ -70,6 +75,19 @@ public class TreeManager implements Listener {
         if (Tag.LOGS.isTagged(event.getBlock().getType())) {
             Location location = event.getBlock().getLocation();
             getLogRegionData(location).addLocation(location);
+        }
+    }
+
+    public Boolean replantEnabled(Player player) {
+        if (player == null) {
+            return true;
+        }
+        return player.getPersistentDataContainer().getOrDefault(replantPdcKey, PersistentDataType.BOOLEAN, true);
+    }
+
+    public void setReplantEnabled(Player player, boolean replant) {
+        if (player != null) {
+            player.getPersistentDataContainer().set(replantPdcKey, PersistentDataType.BOOLEAN, replant);
         }
     }
 

--- a/src/main/java/com/froobworld/nabsuite/modules/mechs/trees/TreeReplanter.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/mechs/trees/TreeReplanter.java
@@ -1,10 +1,7 @@
 package com.froobworld.nabsuite.modules.mechs.trees;
 
 import com.froobworld.nabsuite.modules.mechs.MechsModule;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Tag;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -18,13 +15,12 @@ public class TreeReplanter implements Listener {
     public TreeReplanter(MechsModule mechsModule, TreeManager treeManager) {
         this.mechsModule = mechsModule;
         this.treeManager = treeManager;
-
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
     private void onBlockBreak(BlockBreakEvent event) {
         if (Tag.LOGS.isTagged(event.getBlock().getType())) {
-            if (treeManager.isNaturalLog(event.getBlock().getLocation())) {
+            if (treeManager.replantEnabled(event.getPlayer()) && treeManager.isNaturalLog(event.getBlock().getLocation())) {
                 Material saplingMaterial = saplingTypeForWood(event.getBlock().getType());
                 if (saplingMaterial != null) {
                     schedulePlantTask(event.getBlock().getLocation(), saplingMaterial);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -323,8 +323,8 @@ permissions:
     description: "Access to the /effectivevd command."
   nabsuite.command.borderwarning:
     description: "Access to the /borderwarning command."
-  nabsuite.command.autoreplant:
-    description: "Access to the /autoreplant command."
+  nabsuite.command.noreplant:
+    description: "Access to the /noreplant command."
 
   # Mechs module other permissions
   nabsuite.nabmode:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -323,6 +323,8 @@ permissions:
     description: "Access to the /effectivevd command."
   nabsuite.command.borderwarning:
     description: "Access to the /borderwarning command."
+  nabsuite.command.autoreplant:
+    description: "Access to the /autoreplant command."
 
   # Mechs module other permissions
   nabsuite.nabmode:


### PR DESCRIPTION
Auto replant can be annoying sometimes when you try to clear trees from an area and forget to break saplings.

This change adds the /autoreplant command to toggle automatic replanting.

