### PR TITLE
Add no-home flag to claims

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/basics/command/HomeCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/command/HomeCommand.java
@@ -6,6 +6,7 @@ import com.froobworld.nabsuite.command.NabCommand;
 import com.froobworld.nabsuite.modules.basics.BasicsModule;
 import com.froobworld.nabsuite.modules.basics.command.argument.HomeArgument;
 import com.froobworld.nabsuite.modules.basics.teleport.home.Home;
+import com.froobworld.nabsuite.modules.basics.event.TeleportHomeEvent;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.CommandSender;
@@ -28,11 +29,14 @@ public class HomeCommand extends NabCommand {
     public void execute(CommandContext<CommandSender> context) {
         Player player = (Player) context.getSender();
         Home home = context.get("home");
-        basicsModule.getPlayerTeleporter().teleportAsync(player, home.getLocation()).thenAccept(v -> {
-            player.sendMessage(
-                    Component.text("There's no place like home...").color(NamedTextColor.YELLOW)
-            );
-        });
+        TeleportHomeEvent event = new TeleportHomeEvent(player, home);
+        if (event.callEvent()) {
+            basicsModule.getPlayerTeleporter().teleportAsync(player, home.getLocation()).thenAccept(v -> {
+                player.sendMessage(
+                        Component.text("There's no place like home...").color(NamedTextColor.YELLOW)
+                );
+            });
+        }
     }
 
     @Override

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/command/SetHomeCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/command/SetHomeCommand.java
@@ -7,6 +7,7 @@ import com.froobworld.nabsuite.command.NabCommand;
 import com.froobworld.nabsuite.command.argument.arguments.StringArgument;
 import com.froobworld.nabsuite.command.argument.predicate.ArgumentPredicate;
 import com.froobworld.nabsuite.command.argument.predicate.predicates.PatternArgumentPredicate;
+import com.froobworld.nabsuite.modules.basics.event.CreateHomeEvent;
 import com.froobworld.nabsuite.modules.basics.BasicsModule;
 import com.froobworld.nabsuite.modules.basics.teleport.home.Home;
 import com.froobworld.nabsuite.modules.basics.teleport.home.HomeManager;
@@ -41,10 +42,13 @@ public class SetHomeCommand extends NabCommand {
             return;
         }
 
-        Home home = basicsModule.getHomeManager().createHome(player, homeName);
-        player.sendMessage(
-                Component.text("Created home '" + home.getName() + "' at your location.").color(NamedTextColor.YELLOW)
-        );
+        CreateHomeEvent event = new CreateHomeEvent(player, player.getLocation(), homeName);
+        if (event.callEvent()) {
+            Home home = basicsModule.getHomeManager().createHome(player, homeName);
+            player.sendMessage(
+                    Component.text("Created home '" + home.getName() + "' at your location.").color(NamedTextColor.YELLOW)
+            );
+        }
     }
 
     @Override

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/event/CreateHomeEvent.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/event/CreateHomeEvent.java
@@ -1,0 +1,54 @@
+package com.froobworld.nabsuite.modules.basics.event;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class CreateHomeEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+    private boolean cancelled = false;
+    private final Location location;
+    private final Player player;
+    private final String homeName;
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    public CreateHomeEvent(Player player, Location location, String homeName) {
+        super();
+        this.player = player;
+        this.location = location;
+        this.homeName = homeName;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public String getHomeName() {
+        return homeName;
+    }
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/event/CreateHomeEvent.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/event/CreateHomeEvent.java
@@ -3,15 +3,14 @@ package com.froobworld.nabsuite.modules.basics.event;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
 
-public class CreateHomeEvent extends Event implements Cancellable {
+public class CreateHomeEvent extends PlayerEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
     private boolean cancelled = false;
     private final Location location;
-    private final Player player;
     private final String homeName;
 
     public static HandlerList getHandlerList() {
@@ -19,8 +18,7 @@ public class CreateHomeEvent extends Event implements Cancellable {
     }
 
     public CreateHomeEvent(Player player, Location location, String homeName) {
-        super();
-        this.player = player;
+        super(player);
         this.location = location;
         this.homeName = homeName;
     }
@@ -42,10 +40,6 @@ public class CreateHomeEvent extends Event implements Cancellable {
 
     public Location getLocation() {
         return location;
-    }
-
-    public Player getPlayer() {
-        return player;
     }
 
     public String getHomeName() {

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/event/TeleportHomeEvent.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/event/TeleportHomeEvent.java
@@ -3,14 +3,13 @@ package com.froobworld.nabsuite.modules.basics.event;
 import com.froobworld.nabsuite.modules.basics.teleport.home.Home;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
 
-public class TeleportHomeEvent extends Event implements Cancellable {
+public class TeleportHomeEvent extends PlayerEvent implements Cancellable {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
     private boolean cancelled = false;
-    private final Player player;
     private final Home home;
 
     public static HandlerList getHandlerList() {
@@ -18,7 +17,7 @@ public class TeleportHomeEvent extends Event implements Cancellable {
     }
 
     public TeleportHomeEvent(Player player, Home home) {
-        super();
+        super(player);
         this.player = player;
         this.home = home;
     }
@@ -36,10 +35,6 @@ public class TeleportHomeEvent extends Event implements Cancellable {
     @Override
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
-    }
-
-    public Player getPlayer() {
-        return player;
     }
 
     public Home getHome() {

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/event/TeleportHomeEvent.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/event/TeleportHomeEvent.java
@@ -1,0 +1,48 @@
+package com.froobworld.nabsuite.modules.basics.event;
+
+import com.froobworld.nabsuite.modules.basics.teleport.home.Home;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class TeleportHomeEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+    private boolean cancelled = false;
+    private final Player player;
+    private final Home home;
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    public TeleportHomeEvent(Player player, Home home) {
+        super();
+        this.player = player;
+        this.home = home;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public Home getHome() {
+        return home;
+    }
+}

--- a/src/main/java/com/froobworld/nabsuite/modules/basics/event/TeleportHomeEvent.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/event/TeleportHomeEvent.java
@@ -18,7 +18,6 @@ public class TeleportHomeEvent extends PlayerEvent implements Cancellable {
 
     public TeleportHomeEvent(Player player, Home home) {
         super(player);
-        this.player = player;
         this.home = home;
     }
 

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/area/AreaManager.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/area/AreaManager.java
@@ -189,7 +189,8 @@ public class AreaManager {
                 new NoMobGriefFlagEnforcer(this),
                 new NoPvpFlagEnforcer(this),
                 new KeepInventoryFlagEnforcer(this),
-                new NoWitherFlagEnforcer(this)
+                new NoWitherFlagEnforcer(this),
+                new NoHomeFlagEnforcer(this)
         ).forEach(enforcer -> Bukkit.getPluginManager().registerEvents(enforcer, protectModule.getPlugin()));
     }
 

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/area/AreaNotificationManager.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/area/AreaNotificationManager.java
@@ -14,8 +14,12 @@ public class AreaNotificationManager {
     private final Map<Player, Long> lastNotifyMap = new WeakHashMap<>();
 
     public void notifyProtected(Player player) {
+        notifyProtected(player, AREA_PROTECTED_MESSAGE);
+    }
+
+    public void notifyProtected(Player player, Component message) {
         if (System.currentTimeMillis() - lastNotifyMap.getOrDefault(player, -1L) > NOTIFICATION_RATE_LIMIT) {
-            player.sendMessage(AREA_PROTECTED_MESSAGE);
+            player.sendMessage(message);
             lastNotifyMap.put(player, System.currentTimeMillis());
         }
     }

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/area/flag/Flags.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/area/flag/Flags.java
@@ -18,6 +18,7 @@ public final class Flags {
     public static final String NO_MOB_GRIEF = "no-mob-grief";
     public static final String KEEP_INVENTORY = "keep-inventory";
     public static final String NO_WITHER = "no-wither";
+    public static final String NO_HOME = "no-home";
 
     public static final Set<String> flags = Set.of(
             NO_BUILD,
@@ -31,7 +32,8 @@ public final class Flags {
             NO_MOB_DAMAGE,
             NO_MOB_GRIEF,
             KEEP_INVENTORY,
-            NO_WITHER
+            NO_WITHER,
+            NO_HOME
     );
 
 }

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/area/flag/enforcers/NoHomeFlagEnforcer.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/area/flag/enforcers/NoHomeFlagEnforcer.java
@@ -1,0 +1,64 @@
+package com.froobworld.nabsuite.modules.protect.area.flag.enforcers;
+
+import com.destroystokyo.paper.event.player.PlayerSetSpawnEvent;
+import com.froobworld.nabsuite.modules.basics.event.CreateHomeEvent;
+import com.froobworld.nabsuite.modules.basics.event.TeleportHomeEvent;
+import com.froobworld.nabsuite.modules.protect.area.AreaLike;
+import com.froobworld.nabsuite.modules.protect.area.AreaManager;
+import com.froobworld.nabsuite.modules.protect.area.flag.Flags;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class NoHomeFlagEnforcer implements Listener {
+    private final AreaManager areaManager;
+
+    public NoHomeFlagEnforcer(AreaManager areaManager) {
+        this.areaManager = areaManager;
+    }
+
+    private boolean canUseHome(Location location, Player player) {
+        for (AreaLike area : areaManager.getTopMostAreasAtLocation(location)) {
+            if (area.hasFlag(Flags.NO_HOME) && !area.hasUserRights(player)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    public void onCreateHome(CreateHomeEvent event) {
+        if (!canUseHome(event.getLocation(), event.getPlayer())) {
+            event.getPlayer().sendMessage(
+                    Component.text("This area does not allow setting homes.").color(NamedTextColor.RED)
+            );
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    public void onTeleportHome(TeleportHomeEvent event) {
+        if (!canUseHome(event.getHome().getLocation(), event.getPlayer())) {
+            event.getPlayer().sendMessage(
+                    Component.text("Destination area does not allow teleporting.").color(NamedTextColor.RED)
+            );
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    public void onPlayerSetSpawn(PlayerSetSpawnEvent event) {
+        if (event.getCause() == PlayerSetSpawnEvent.Cause.BED || event.getCause() == PlayerSetSpawnEvent.Cause.RESPAWN_ANCHOR) {
+            if (!canUseHome(event.getLocation(), event.getPlayer())) {
+                areaManager.getAreaNotificationManager().notifyProtected(event.getPlayer(), Component.text("This area does not allow respawn points.").color(NamedTextColor.RED));
+                event.setCancelled(true);
+            }
+        }
+    }
+
+
+}


### PR DESCRIPTION
Adds a `no-home` flag, it prevents players that aren't added to the area from
* Using `/sethome` in the area
* Using `/home` to teleport to the area
* Setting spawn point via bed or respawn anchor in the area