### PR TITLE
AFK Warnings

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/basics/config/BasicsConfig.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/basics/config/BasicsConfig.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.function.Function;
 
 public class BasicsConfig extends NabConfiguration {
-    private static final int CONFIG_VERSION = 6;
+    private static final int CONFIG_VERSION = 7;
 
     public BasicsConfig(BasicsModule basicsModule) {
         super(
@@ -38,6 +38,9 @@ public class BasicsConfig extends NabConfiguration {
 
         @Entry(key = "afk-kick-time")
         public final ConfigEntry<Long> afkKickTime = ConfigEntries.longEntry();
+
+        @Entry(key = "afk-warn-time")
+        public final ConfigEntry<Long> afkWarnTime = ConfigEntries.longEntry();
 
     }
 

--- a/src/main/resources/resources/basics/config-patches/6.patch
+++ b/src/main/resources/resources/basics/config-patches/6.patch
@@ -1,0 +1,4 @@
+[add-field]
+key=afk-settings.afk-warn-time
+value=30
+comment=# Time in seconds to warn the player before automatic afk or kick


### PR DESCRIPTION
There has been a few cases where a player is writing in a book without going `/afk` first, then lose all their text when getting kicked for afk, and lots of times where a player auto-afk:s and then instantly un-afk:s because they weren't actually afk.

This PR adds a countdown until auto-afk and afk-kick so the player gets a heads up before the automatic actions.

New config option `afk-settings.afk-warn-time` (default 30 seconds). Can be set to 0 to disable the feature.

Starts a countdown in the action bar right before auto-afk:

![Screenshot From 2025-06-15 13-59-12](https://github.com/user-attachments/assets/661d7b9e-8b52-4a39-a872-d7971fd0cdfe)


Countdown as title before afk kick:

![Screenshot From 2025-06-15 14-00-11](https://github.com/user-attachments/assets/88c239dc-5b21-498e-8832-e67125d33903)
