### PR TITLE
Add inherit-users flag for subareas

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/protect/area/Area.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/area/Area.java
@@ -2,6 +2,7 @@ package com.froobworld.nabsuite.modules.protect.area;
 
 import com.froobworld.nabsuite.data.SchemaEntries;
 import com.froobworld.nabsuite.data.SimpleDataSchema;
+import com.froobworld.nabsuite.modules.protect.area.flag.Flags;
 import com.froobworld.nabsuite.user.User;
 import com.froobworld.nabsuite.user.UserManager;
 import org.bukkit.Location;
@@ -177,7 +178,7 @@ public class Area implements AreaLike {
                 return true;
             }
         }
-        return false;
+        return hasFlag(Flags.INHERIT_USERS) && parent != null && parent.isUser(player);
     }
 
     public boolean isManager(Player player) {
@@ -186,7 +187,7 @@ public class Area implements AreaLike {
                 return true;
             }
         }
-        return false;
+        return hasFlag(Flags.INHERIT_USERS) && parent != null && parent.isManager(player);
     }
 
     public boolean isOwner(Player player) {
@@ -195,7 +196,7 @@ public class Area implements AreaLike {
                 return true;
             }
         }
-        return false;
+        return hasFlag(Flags.INHERIT_USERS) && parent != null && parent.isOwner(player);
     }
 
     public void addUser(User user) {

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/area/flag/Flags.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/area/flag/Flags.java
@@ -19,6 +19,7 @@ public final class Flags {
     public static final String KEEP_INVENTORY = "keep-inventory";
     public static final String NO_WITHER = "no-wither";
     public static final String NO_HOME = "no-home";
+    public static final String INHERIT_USERS = "inherit-users";
 
     public static final Set<String> flags = Set.of(
             NO_BUILD,
@@ -33,7 +34,8 @@ public final class Flags {
             NO_MOB_GRIEF,
             KEEP_INVENTORY,
             NO_WITHER,
-            NO_HOME
+            NO_HOME,
+            INHERIT_USERS
     );
 
 }

--- a/src/main/java/com/froobworld/nabsuite/modules/protect/command/AreaAddFlagCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/protect/command/AreaAddFlagCommand.java
@@ -7,6 +7,7 @@ import com.froobworld.nabsuite.command.argument.predicate.ArgumentPredicate;
 import com.froobworld.nabsuite.modules.protect.ProtectModule;
 import com.froobworld.nabsuite.modules.protect.area.Area;
 import com.froobworld.nabsuite.modules.protect.area.AreaManager;
+import com.froobworld.nabsuite.modules.protect.area.flag.Flags;
 import com.froobworld.nabsuite.modules.protect.command.argument.AreaArgument;
 import com.froobworld.nabsuite.modules.protect.command.argument.FlagArgument;
 import net.kyori.adventure.text.Component;
@@ -75,6 +76,14 @@ public class AreaAddFlagCommand extends NabCommand {
                                             return !area.hasFlag(flag);
                                         },
                                         "The area already has that flag."
+                                ),
+                                new ArgumentPredicate<>(
+                                        false,
+                                        (context, flag) -> {
+                                            Area area = context.get("area");
+                                            return !flag.equals(Flags.INHERIT_USERS) || area.getParent() != null;
+                                        },
+                                        "The flag is only available for subareas."
                                 )
                         )
                 );


### PR DESCRIPTION
Added flag `inherit-users` for subareas. If enabled the user/manager/owner checks will check access of the parent area if the user is not explicitly added to the subarea