### PR TITLE
Migrate creativeLevel flag to PDC

### DIFF
--- a/src/main/java/com/froobworld/nabsuite/modules/nabmode/command/NabsBeGoneCommand.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/nabmode/command/NabsBeGoneCommand.java
@@ -44,10 +44,15 @@ public class NabsBeGoneCommand extends NabCommand {
     private void sendAway(Player player) {
         Location backLocation = basicsModule.getBackManager().getBackLocation(player);
         Location respawnLocation = player.getRespawnLocation();
-        if (respawnLocation != null && nabDimensionManager.getNabWorld().equals(respawnLocation.getWorld())) {
-            player.setRespawnLocation(null);
-        } else if (backLocation == null || nabDimensionManager.getNabWorld().equals(backLocation.getWorld())) {
-            backLocation = respawnLocation;
+        if (backLocation != null && nabDimensionManager.getNabWorld().equals(backLocation.getWorld())) {
+            backLocation = null;
+        }
+        if (respawnLocation != null) {
+            if (nabDimensionManager.getNabWorld().equals(respawnLocation.getWorld())) {
+                player.setRespawnLocation(null);
+            } else if (backLocation == null) {
+                backLocation = respawnLocation;
+            }
         }
         if (backLocation == null) {
             backLocation = basicsModule.getSpawnManager().getSpawnLocation();

--- a/src/main/java/com/froobworld/nabsuite/modules/nabmode/nabdimension/NabDimensionManager.java
+++ b/src/main/java/com/froobworld/nabsuite/modules/nabmode/nabdimension/NabDimensionManager.java
@@ -20,12 +20,14 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
 
-import static org.joor.Reflect.*;
+import static org.joor.Reflect.on;
 
 public class NabDimensionManager implements Listener {
     private final NabModeModule nabModeModule;
     private boolean haveWarned = false;
+    private final NamespacedKey creativeLevelKey = new NamespacedKey("nabulus", "creative_level");
     private final World nabWorld;
     private static final Tag<Material> illegalBlocks = new MaterialSetTag(NamespacedKey.fromString("illegal_blocks"))
             .add(Material.BEDROCK)
@@ -58,18 +60,23 @@ public class NabDimensionManager implements Listener {
     }
 
     private boolean hasFlagSet() {
-        try {
-            return on(nabWorld)
-                    .call("getHandle")
-                    .call("getLevelData") // get WorldData
-                    .get("creativeLevel");
-        } catch (Exception e) {
-            if (!haveWarned) {
-                nabModeModule.getPlugin().getSLF4JLogger().error("Mappings update required?", e);
-                haveWarned = true;
+        Boolean flag = nabWorld.getPersistentDataContainer().get(creativeLevelKey, PersistentDataType.BOOLEAN);
+        if (flag == null) {
+            try {
+                flag = on(nabWorld)
+                        .call("getHandle")
+                        .call("getLevelData") // get WorldData
+                        .get("creativeLevel");
+                nabWorld.getPersistentDataContainer().set(creativeLevelKey, PersistentDataType.BOOLEAN, flag);
+            } catch (Exception e) {
+                if (!haveWarned) {
+                    nabModeModule.getPlugin().getSLF4JLogger().error("Mappings update required?", e);
+                    haveWarned = true;
+                }
+                return false;
             }
-            return false;
         }
+        return flag;
     }
 
     @EventHandler


### PR DESCRIPTION
Migrates the creativeLevel flag to PDC variable `nabsuite:creative_level`.
Checks if the PDC variable is set before falling back to reflection

Nabsuite should be updated and run once before migrating to 26.1

Fix logic issue in `/nabsbegone`: if both back location and respawn location was in nabworld, the player would be sent to back location regardless